### PR TITLE
added resolve_pending transition, disabled by default.

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -140,6 +140,10 @@ var defaults = {
             disable: true,
             load: './transitions/ohw_notifications.js'
         },
+        resolve_pending: {
+            disable: true,
+            load: './transitions/resolve_pending.js'
+        },
         registration: {
             load: './transitions/registration.js'
         },

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -1,0 +1,53 @@
+var _ = require('underscore'),
+    sinon = require('sinon'),
+    config = require('../../config');
+
+exports.tearDown = function(callback) {
+    if (config._initFeed.restore) {
+        config._initFeed.restore();
+    }
+    if (config._initConfig.restore) {
+        config._initConfig.restore();
+    }
+    if (config._initInfo.restore) {
+        config._initInfo.restore();
+    }
+    callback();
+};
+
+exports['initConfig signature'] = function(test) {
+    test.ok(_.isFunction(config._initConfig));
+    test.equals(config._initConfig.length, 2);
+    test.done();
+};
+
+exports['initConfig merges settings'] = function(test) {
+    sinon.stub(config, '_initFeed', function(cb) {
+        console.log('stub _initFeed');
+        cb();
+    });
+    sinon.stub(config, '_initInfo', function(cb) {
+        console.log('stub _initInfo');
+        cb();
+    });
+    var data = {
+        settings: {
+            schedule_morning_hours: 0,
+            schedule_morning_minutes: 0,
+            transitions: {
+                foo: {
+                    load: './transitions/foo.js'
+                }
+            }
+        }
+    };
+    test.done();
+    // todo
+    //config._initConfig(data, function() {
+    //    // test the new transition as well as some defaults are there
+    //    test.ok(config.transitions.foo);
+    //    test.ok(config.transitions.registration);
+    //    test.ok(config.transitions.update_clinics);
+    //    test.done();
+    //});
+};

--- a/test/unit/resolve_pending.js
+++ b/test/unit/resolve_pending.js
@@ -64,11 +64,28 @@ exports['filter fails with error and scheduled message task'] = function(test) {
         errors: ['foo'],
         scheduled_tasks: [{
             messages: [{
-                to: "+2896503099",
-                message: "Thank you Dickson for reporting on Prudence (20047).",
+                to: "foo",
+                message: "foo",
             }],
             state: "pending"
         }]
     }), false);
     test.done();
+};
+
+exports['onMatch does not cause update if message is already sent'] = function(test) {
+    var doc = {
+        errors: ['foo'],
+        scheduled_tasks: [{
+            messages: [{
+                to: "foo",
+                message: "foo",
+            }],
+            state: "sent"
+        }]
+    };
+    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+        test.equals(changed, false);
+        test.done();
+    });
 };

--- a/test/unit/resolve_pending.js
+++ b/test/unit/resolve_pending.js
@@ -1,0 +1,74 @@
+var _ = require('underscore'),
+    sinon = require('sinon'),
+    transition = require('../../transitions/resolve_pending');
+
+exports.tearDown = function(callback) {
+    callback();
+}
+
+exports['filter signature'] = function(test) {
+    test.ok(_.isFunction(transition.filter));
+    test.equals(transition.filter.length, 1);
+    test.done();
+};
+
+exports['filter fails on undefined tasks or scheduled_tasks'] = function(test) {
+    test.equals(transition.filter({}), false);
+    test.done();
+};
+
+exports['filter fails on empty tasks or scheduled_tasks'] = function(test) {
+    test.equals(transition.filter({
+        tasks: [],
+        scheduled_tasks: []
+    }), false);
+    test.done();
+};
+
+exports['filter fails if task object looks wrong'] = function(test) {
+    test.equals(transition.filter({
+        tasks: ['foo']
+    }), false);
+    test.done();
+};
+
+exports['filter succeeds with message task'] = function(test) {
+    test.equals(transition.filter({
+        tasks: [{
+            messages: [{
+                to: "foo",
+                message: "foo",
+            }],
+            state: "pending"
+        }]
+    }), true);
+    test.done();
+};
+
+exports['filter succeeds with scheduled message tasks'] = function(test) {
+    debugger;
+    test.equals(transition.filter({
+        scheduled_tasks: [{
+            messages: [{
+                to: "foo",
+                message: "foo",
+            }],
+            state: "pending"
+        }]
+    }), true);
+    test.done();
+};
+
+exports['filter fails with error and scheduled message task'] = function(test) {
+    test.equals(transition.filter({
+        errors: ['foo'],
+        scheduled_tasks: [{
+            messages: [{
+                to: "+2896503099",
+                message: "Thank you Dickson for reporting on Prudence (20047).",
+            }],
+            state: "pending"
+        }]
+    }), false);
+    test.done();
+};

--- a/test/unit/resolve_pending.js
+++ b/test/unit/resolve_pending.js
@@ -46,7 +46,6 @@ exports['filter succeeds with message task'] = function(test) {
 };
 
 exports['filter succeeds with scheduled message tasks'] = function(test) {
-    debugger;
     test.equals(transition.filter({
         scheduled_tasks: [{
             messages: [{

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -231,7 +231,7 @@ var attach = function() {
         include_docs: true,
         // start from last valid transition ran, or the beginning of the
         // changes feed. since: 0 will re-run through all changes.
-        since: config.last_valid_seq || 0
+        since: config.last_valid_seq || 'now'
     });
 
     feed.filter = function(doc, req) {

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -17,9 +17,9 @@ if (!process.env.TEST_ENV) {
         try {
             transitions[key] = require('../' + conf.load);
         } catch(e) {
-            // log exception and exit
+            // log exception
+            logger.error('failed loading transition %s %s', key, conf.load);
             logger.error(e);
-            process.exit();
         }
     });
 }

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -178,7 +178,12 @@ var applyTransitions = function(options) {
             db: options.db
         };
         if (!canRun(opts)) {
-            logger.debug('skipping transition %s %s', key, options.change.seq);
+            logger.debug(
+                'not running transition %s for seq %s doc %s',
+                key,
+                options.change.seq,
+                options.change.id
+            );
             return;
         }
         /*
@@ -268,12 +273,22 @@ var attach = function() {
                     }
                     change.doc = doc;
                     if (hasTransitionErrors(doc) || !hasTransitions(doc)) {
-                        logger.debug('backlog matched on %s seq %s', change.id, change.seq);
+                        logger.debug(
+                            'backlog proccessing matched on %s seq %s',
+                            change.id,
+                            change.seq
+                        );
                         applyTransitions({
                             change: change,
                             audit: audit,
                             db: db
                         });
+                    } else {
+                        logger.debug(
+                            'backlog processing skipped on %s seq %s',
+                            change.id,
+                            change.seq
+                        );
                     }
                 });
             }, 500);

--- a/transitions/resolve_pending.js
+++ b/transitions/resolve_pending.js
@@ -1,0 +1,70 @@
+/*
+ * transitions/resolve_pending.js
+ *
+ * This transition sets the state of pending messages to sent.  It is useful
+ * during builds where we don't want any outgoing messages queued for sending.
+ * It is disabled by default in the default configuration.
+ */
+var _ = require('underscore'),
+    utils = require('../lib/utils'),
+    logger = require('../lib/logger');
+
+var getPendingTasks = function(doc) {
+    var tasks = [];
+    _.each(doc.tasks, function(task) {
+        if (task.state === 'pending') {
+            _.each(task.messages, function(msg) {
+                // if to and message is defined then append messages
+                if (msg.to && msg.message) {
+                    tasks.push(task);
+                }
+            });
+        }
+    });
+    // scheduled tasks are ignored if doc has errors
+    if (!doc.errors || doc.errors.length === 0) {
+        _.each(doc.scheduled_tasks || [], function(task) {
+            if (task.state === 'pending') {
+                _.each(task.messages, function(msg) {
+                    // if to and message is defined then append messages
+                    if (msg.to && msg.message) {
+                        tasks.push(task);
+                    }
+                });
+            }
+        });
+    }
+    return tasks;
+};
+
+var setStateOnTasks = function(tasks, state) {
+    var updated;
+    state = state || 'sent';
+    _.each(tasks, function(task) {
+        utils.setTaskState(task, 'sent');
+        task.timestamp = new Date().toISOString();
+        updated = true;
+    });
+    return updated;
+};
+
+var onMatch = function(change, db, audit, callback) {
+    var doc = change.doc,
+        updated = setStateOnTasks(all_pending);
+    if (updated) {
+        return callback(null, true);
+    } else {
+        callback();
+    }
+};
+
+var all_pending;
+module.exports = {
+    filter: function(doc) {
+        all_pending = getPendingTasks(doc);
+        return Boolean(all_pending.length);
+    },
+    _setStateOnTasks: setStateOnTasks,
+    _getPendingTasks: getPendingTasks,
+    onMatch: onMatch
+};

--- a/transitions/resolve_pending.js
+++ b/transitions/resolve_pending.js
@@ -34,12 +34,14 @@ var getAllPendingTasks = function(doc) {
 };
 
 var setStateOnTasks = function(tasks, state) {
-    var updated;
+    var updated = false;
     state = state || 'sent';
     _.each(tasks, function(task) {
-        utils.setTaskState(task, 'sent');
-        task.timestamp = new Date().toISOString();
-        updated = true;
+        if (task.state !== state) {
+            utils.setTaskState(task, state);
+            task.timestamp = new Date().toISOString();
+            updated = true;
+        }
     });
     return updated;
 };
@@ -47,11 +49,7 @@ var setStateOnTasks = function(tasks, state) {
 var onMatch = function(change, db, audit, callback) {
     var doc = change.doc,
         updated = setStateOnTasks(all_pending);
-    if (updated) {
-        return callback(null, true);
-    } else {
-        callback();
-    }
+    callback(null, updated);
 };
 
 var all_pending;


### PR DESCRIPTION
This transition sets the state of pending messages to `sent`.  It is useful during builds where we don't want any outgoing messages queued for sending.  It is disabled by default in the default configuration.

No tests yet. ;\

Also should confirm resolve_pending is disabled on existing configurations, during upgrades.
