### PR TITLE
modified validation lib to better support unicode query values.

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -32,10 +32,13 @@ var _exists = function(doc, query, callback) {
 };
 
 var _formatParam = function(name, value) {
-    return encodeURIComponent(name) + ':"' + encodeURIComponent(value) + '"';
+    name = name.replace(/"/g, '');
+    value = value.replace(/"/g, '\\"');
+    return name + ':"' + value + '"';
 };
 
 module.exports = {
+    _formatParam: _formatParam,
     extractErrors: function(result, messages, ignores) {
         // wrap single item in array; defaults to empty array
         ignores = ignores || [];

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -244,6 +244,27 @@ exports['pass uniqueWithin validation on old doc'] = function(test) {
     });
 };
 
+exports['formatParam does not encode unicode'] = function(test) {
+    test.same(validation._formatParam('form', 'द'), 'form:"द"');
+    test.done();
+};
+
+exports['formatParam escapes quotes in values'] = function(test) {
+    test.same(
+        validation._formatParam('form', ' " AND everything'),
+        'form:" \\" AND everything"'
+    );
+    test.done();
+};
+
+exports['formatParam rejects quotes in field names'] = function(test) {
+    test.same(
+        validation._formatParam('*:"everything', 'xyz'),
+        '*:everything:"xyz"'
+    );
+    test.done();
+};
+
 exports['pass exists validation when matching document'] = function(test) {
     test.expect(2);
     // simulate view results with doc attribute


### PR DESCRIPTION
Issue: https://github.com/medic/medic-webapp/issues/1147

Stopped URL encoding parameters before passing to couchdb lucene/fti lib
because otherwise they are encoded twice. Only escaping quotes to
prevent injections.

This validation lib will probably get refactored soon to use
https://github.com/medic/lucene-query-generator but for now wanted to
fix a bug that prevents using `exists('द', 'patient_id')` validation
on a patient visit form.