### PR TITLE
added support for outgoing_deny_list conf in default_response transit…

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -20,7 +20,8 @@ function addMessage(opts) {
         try {
             utils.addMessage(doc, {
                 phone: String(phone),
-                message: template.render(opts.message, details)
+                message: template.render(opts.message, details),
+                state: opts.state
             });
         } catch(e) {
             utils.addError(doc, {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -147,7 +147,7 @@ var addMessage = function(doc, options) {
         ]
     });
 
-    setTaskState(task, 'pending');
+    setTaskState(task, options.state || 'pending');
 
     doc.tasks.push(task);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -508,6 +508,11 @@ module.exports = {
     /*
      * Return message from configured translations given key and locale.
      *
+     * If translation is not found return the translation key.  Otherwise
+     * messages won't get added because of an empty message.  Better to at
+     * least surface something in the UI providing a clue that something is
+     * misconfigured as opposed to broken.
+     *
      * @param {String} key - translation key/identifier
      * @param {String} locale - short locale string
      *
@@ -516,7 +521,7 @@ module.exports = {
     translate: function(key, locale) {
 
         var translations = config.get('translations'),
-            msg;
+            msg = key;
 
         _.each(translations, function(t) {
             if (t.key === key) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -529,5 +529,8 @@ module.exports = {
 
         return msg;
 
+    },
+    escapeRegex: function(s) {
+        return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     }
 }

--- a/test/unit/default_responses.js
+++ b/test/unit/default_responses.js
@@ -466,3 +466,57 @@ exports['add response to empty message'] = function (test) {
     });
 };
 
+exports['add response when recipient is allowed'] = function (test) {
+    sinon.stub(transition, '_isResponseAllowed').returns(true);
+    sinon.stub(config, 'get').withArgs('translations').returns([
+        {
+            'key': 'sms_received',
+            'default': 'ahoy mate'
+        }
+    ]);
+    var messageFn = sinon.spy(messages, 'addMessage');
+    test.expect(4);
+    var doc = {
+        from: 'x',
+        type: 'data_record'
+    };
+    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+        test.ok(messageFn.calledOnce);
+        test.ok(messageFn.calledWith({
+            doc: doc,
+            phone: 'x',
+            message: 'ahoy mate'
+        }));
+        test.equals(err, null);
+        test.equals(changed, true);
+        test.done();
+    });
+};
+
+exports['add response with denied state when recipient is denied'] = function (test) {
+    sinon.stub(transition, '_isResponseAllowed').returns(false);
+    sinon.stub(config, 'get').withArgs('translations').returns([
+        {
+            'key': 'sms_received',
+            'default': 'ahoy mate'
+        }
+    ]);
+    var messageFn = sinon.spy(messages, 'addMessage');
+    test.expect(4);
+    var doc = {
+        from: 'x',
+        type: 'data_record'
+    };
+    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+        test.ok(messageFn.calledOnce);
+        test.ok(messageFn.calledWith({
+            doc: doc,
+            phone: 'x',
+            message: 'ahoy mate',
+            state: 'denied'
+        }));
+        test.equals(err, null);
+        test.equals(changed, true);
+        test.done();
+    });
+};

--- a/test/unit/default_responses.js
+++ b/test/unit/default_responses.js
@@ -137,7 +137,7 @@ exports['describe _isResponseAllowed'] = function(test) {
      * or MNO (mobile network operator) defined string.
      */
     var tests = [
-      // rejected
+      // denied
       ['+123', '+123', false],
       ['+123', '+123999999', false],
       ['SAFARI', 'SAFARICOM', false],
@@ -145,10 +145,18 @@ exports['describe _isResponseAllowed'] = function(test) {
       ['+123,+456,+789', '+456', false],
       ['+123,+456,+789', '+4569999999', false],
       ['SAFARI, ORANGE', 'ORANGE NET', false],
+      ['0', '0000123', false],
+      ['0', '0', false],
       // allowed
       ['+123', '+999', true],
       ['SAFARI, ORANGE NET', 'ORANGE', true],
-      ['VIVO', 'EM VIVO', true]
+      ['VIVO', 'EM VIVO', true],
+      ['0', '-1', true],
+      // allow falsey inputs
+      ['snarf', undefined, true],
+      ['snarf', null, true],
+      ['', '+123', true],
+      ['', '', true]
     ];
     _.each(tests, function(t) {
       var s = sinon.stub(transition, '_getConfig');

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -3,11 +3,15 @@ process.env.TEST_ENV = 'hello'; // required for ../../db.js
 var _ = require('underscore'),
     db = require('../../db'),
     sinon = require('sinon'),
-    utils = require('../../lib/utils');
+    utils = require('../../lib/utils'),
+    config = require('../../config');
 
 exports.tearDown = function(callback) {
     if (db.view.restore) {
         db.view.restore();
+    }
+    if (config.get.restore) {
+        config.get.restore();
     }
     callback();
 }
@@ -410,5 +414,22 @@ exports['applyPhoneFilters performs replace'] = function(test) {
     test.equals(utils.applyPhoneFilters(config, '456'), '456');
     test.equals(utils.applyPhoneFilters(config, '159841125'), '29841125');
 
+    test.done();
+}
+
+exports['translate returns message if key found in translations'] = function(test) {
+    sinon.stub(config, 'get').withArgs('translations').returns([
+        {
+          key: 'sms_received',
+          default: 'got it!'
+        }
+    ]);
+    test.equals(utils.translate('sms_received'), 'got it!');
+    test.done();
+}
+
+exports['translate returns key if translations not found'] = function(test) {
+    sinon.stub(config, 'get').withArgs('translations').returns([]);
+    test.equals(utils.translate('sms_received'), 'sms_received');
     test.done();
 }

--- a/transitions/default_responses.js
+++ b/transitions/default_responses.js
@@ -38,8 +38,8 @@ module.exports = {
             return false;
         }
         return _.every(conf.split(','), function(s) {
-            // skip empty strings
-            if (!s) {
+            // ignore falsey inputs
+            if (!s || !doc.from) {
                 return true;
             }
             return !doc.from.match(

--- a/transitions/default_responses.js
+++ b/transitions/default_responses.js
@@ -30,6 +30,12 @@ module.exports = {
     },
     /*
      * Return false when the recipient phone matches the denied list.
+     *
+     * outgoing_deny_list is a comma separated list of strings. If a string in
+     * that list matches the beginning of the phone then we set up a response
+     * with a denied state. The pending message process will ignore these
+     * messages and those reports will be left without an auto-reply. The
+     * denied messages still show up in the messages export.
      */
     _isResponseAllowed: function(doc) {
         var self = module.exports,

--- a/transitions/default_responses.js
+++ b/transitions/default_responses.js
@@ -33,20 +33,19 @@ module.exports = {
      */
     _isResponseAllowed: function(doc) {
         var self = module.exports,
-            conf = self._getConfig('outgoing_deny_list') || '',
-            ret = true;
+            conf = self._getConfig('outgoing_deny_list') || '';
         if (self._isMessageFromGateway(doc)) {
             return false;
         }
-        _.each(conf.split(','), function(s) {
-            // short circuit if we have a match and skip empty strings
-            if (!s || !ret) {
-                return;
+        return _.every(conf.split(','), function(s) {
+            // skip empty strings
+            if (!s) {
+                return true;
             }
-            var re = new RegExp('^' + utils.escapeRegex(s.trim()), 'i');
-            ret = doc.from.match(re) ? false : true;
+            return !doc.from.match(
+                new RegExp('^' + utils.escapeRegex(s.trim()), 'i')
+            );
         });
-        return ret;
     },
     _isReportedAfterStartDate: function(doc) {
         var self = module.exports,

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -19,7 +19,7 @@ if (!process.env.TEST_ENV) {
             transitions[key] = require('../' + conf.load);
         } catch(e) {
             // only log exceptions
-            logger.error(e);
+            logger.error('loading transition failed: ' + e);
         }
     });
 }


### PR DESCRIPTION
outgoing_deny_list is a new configuration that is a comma separated list of strings. If a string in that list matches the beginning of the phone we are setting up a response with a denied state.  The pending message process will ignore these messages and those reports will be left without an auto-reply.   The denied messages still show up in the messages export.

Issue: https://github.com/medic/medic-webapp/issues/750