### PR TITLE
fixed uniqueWithin validation bugs.

### DIFF
--- a/db.js
+++ b/db.js
@@ -42,6 +42,8 @@ module.exports.user = settings.username;
 module.exports.fti = function(index, data, cb) {
     var path = '/_fti/local' + settings.db 
         + '/_design' + settings.db + '/' + index;
+    logger.debug('fti path: ', path);
+    logger.debug('fti query: ', data);
     client.request({
         path: path,
         query: data

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -106,7 +106,7 @@ module.exports = {
             // lucene date range query bug
             // fails: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             // works: "yyyy-MM-dd'T'HH:mm:ss.SSS"
-            var start = moment().subtract(duration).toISOString().replace('Z','');
+            var start = moment().subtract(duration).toISOString().replace(/Z$/,'');
             var endOfTime = '3000-01-01T00:00:00';
             conjunctions.push(
                 'reported_date<date>:[' +  start + ' TO ' + endOfTime + ']'

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -33,8 +33,14 @@ var _exists = function(doc, query, callback) {
 
 var _formatParam = function(name, value) {
     name = name.replace(/"/g, '');
-    value = value.replace(/"/g, '\\"');
-    return name + ':"' + value + '"';
+    if (typeof value === 'string') {
+        value = value.replace(/"/g, '\\"');
+        return name + ':"' + value + '"';
+    }
+    if (typeof value === 'number') {
+        return name + '<int>:' + value;
+    }
+    return name + ':' + value;
 };
 
 module.exports = {
@@ -92,12 +98,15 @@ module.exports = {
             });
         },
         uniqueWithin: function(doc, validation, callback) {
-            var fields = validation.funcArgs;
+            var fields = _.clone(validation.funcArgs);
             var duration = _parseDuration(fields.pop());
             var conjunctions = _.map(fields, function(field) {
                 return _formatParam(field, doc[field]);
             });
-            var start = moment().subtract(duration).toISOString();
+            // lucene date range query bug
+            // fails: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            // works: "yyyy-MM-dd'T'HH:mm:ss.SSS"
+            var start = moment().subtract(duration).toISOString().replace('Z','');
             var endOfTime = '3000-01-01T00:00:00';
             conjunctions.push(
                 'reported_date<date>:[' +  start + ' TO ' + endOfTime + ']'

--- a/test/unit/reminders.js
+++ b/test/unit/reminders.js
@@ -121,8 +121,10 @@ exports['runReminder decorates options with moment if found'] = function(test) {
 };
 
 exports['does not match reminder if in next minute'] = function(test) {
-    var window = sinon.stub(reminders, 'getReminderWindow').callsArgWithAsync(1, null, moment().subtract(1, 'hour')),
+    var past = moment().subtract(1, 'hour'),
         now = moment();
+
+    var window = sinon.stub(reminders, 'getReminderWindow').callsArgWithAsync(1, null, past);
 
     reminders.matchReminder({
         reminder: {


### PR DESCRIPTION
Issue: https://github.com/medic/medic-projects/issues/56

This validation was failing because the lucene query was incorrectly
constructed.

- To query on integer values we need to use the <int> prefix on the
  query otherwise the query doesn't match and always returns an empty
  array.

- formatParam was failing on integer values with:

    lib/validation.js:36
    value = value.replace(/"/g, '\\"');
                  ^
    TypeError: Object 1 has no method 'replace'

- It seems the ISO date standard (the one returned by .toISOString()
  with the trailing Z that designates Zulu/GMT time) fails on Lucene.  I
  opened an upstream issue for this and left a comment in the code.

Net change looks like this:

// fails
```
patient_name:"irene" AND last_menstrual_period:"1" AND reported_date:[2015-07-27T13:14:40.564Z TO 3000-01-01T00:00:00]
```

// works
```
patient_name:"irene" AND last_menstrual_period<int>:1 AND reported_date:[2015-07-27T13:14:40.564 TO 3000-01-01T00:00:00]
```