### PR TITLE
refactored outgoing deny list config handling. 

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -16,7 +16,7 @@ function addMessage(opts) {
     }
 
 
-    if (!utils.isOutgoingAllowed(doc)) {
+    if (!utils.isOutgoingAllowed(doc.from)) {
         opts.state = 'denied';
     }
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -16,6 +16,10 @@ function addMessage(opts) {
     }
 
 
+    if (!utils.isOutgoingAllowed(doc)) {
+        opts.state = 'denied';
+    }
+
     if (phone && opts.message) {
         try {
             utils.addMessage(doc, {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -572,9 +572,8 @@ module.exports = {
             if (!s) {
                 return true;
             }
-            return !from.match(
-                new RegExp('^' + self.escapeRegex(s.trim()), 'i')
-            );
+            // return false if we get a case insensitive starts with match
+            return from.toLowerCase().indexOf(s.trim().toLowerCase()) !== 0;
         });
     },
     /*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 var _ = require('underscore'),
     uuid = require('uuid'),
     moment = require('moment'),
+    libphonenumber = require('libphonenumber'),
     template = require('./template'),
     config = require('../config'),
     i18n = require('../i18n'),
@@ -362,7 +363,8 @@ module.exports = {
             _.first(msg.messages).message = options.message;
     },
     addScheduledMessage: function(doc, options) {
-        var options = options || {},
+        var self = module.exports,
+            options = options || {},
             due = options.due,
             message = options.message,
             phone = applyPhoneFilters(config, options.phone);
@@ -384,7 +386,13 @@ module.exports = {
                 message: message
             }]
         };
-        setTaskState(task, doc.muted ? 'muted' : 'scheduled');
+
+        if (!self.isOutgoingAllowed(doc)) {
+            setTaskState(task, 'denied');
+        } else {
+            setTaskState(task, 'scheduled');
+        }
+
         _.extend(task, options);
         doc.scheduled_tasks.push(task);
     },
@@ -537,5 +545,47 @@ module.exports = {
     },
     escapeRegex: function(s) {
         return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    },
+    /*
+     * Return false when the recipient phone matches the denied list.
+     *
+     * outgoing_deny_list is a comma separated list of strings. If a string in
+     * that list matches the beginning of the phone then we set up a response
+     * with a denied state. The pending message process will ignore these
+     * messages and those reports will be left without an auto-reply. The
+     * denied messages still show up in the messages export.
+     *
+     * @param {String} from - Recipient phone number
+     * @returns {Boolean}
+     */
+    isOutgoingAllowed: function(from) {
+        var self = module.exports,
+            conf = config.get('outgoing_deny_list') || '';
+        if (!from) {
+            return true;
+        }
+        if (self._isMessageFromGateway(from)) {
+            return false;
+        }
+        return _.every(conf.split(','), function(s) {
+            // ignore falsey inputs
+            if (!s) {
+                return true;
+            }
+            return !from.match(
+                new RegExp('^' + self.escapeRegex(s.trim()), 'i')
+            );
+        });
+    },
+    /*
+     * Used to avoid infinite loops of auto-reply messages between gateway and
+     * itself.
+     */
+    _isMessageFromGateway: function(from) {
+        var gw = config.get('gateway_number');
+        if (typeof gw === 'string' && typeof from === 'string') {
+            return libphonenumber.phoneUtil.isNumberMatch(gw, from) >= 3;
+        }
+        return false;
     }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -387,7 +387,7 @@ module.exports = {
             }]
         };
 
-        if (!self.isOutgoingAllowed(doc)) {
+        if (!self.isOutgoingAllowed(doc.from)) {
             setTaskState(task, 'denied');
         } else {
             setTaskState(task, 'scheduled');

--- a/transitions/default_responses.js
+++ b/transitions/default_responses.js
@@ -1,6 +1,5 @@
 var _ = require('underscore'),
     moment = require('moment'),
-    libphonenumber = require('libphonenumber'),
     config = require('../config'),
     utils = require('../lib/utils'),
     logger = require('../lib/logger'),
@@ -16,42 +15,6 @@ module.exports = {
             && !doc.kujua_message
             && self._isReportedAfterStartDate(doc)
         );
-    },
-    /*
-     * Avoid infinite loops of auto-reply messages between gateway and itself.
-     */
-    _isMessageFromGateway: function(doc) {
-        var self = module.exports,
-            gw = self._getConfig('gateway_number');
-        if (typeof gw === 'string' && typeof doc.from === 'string') {
-            return libphonenumber.phoneUtil.isNumberMatch(gw, doc.from) >= 3;
-        }
-        return false;
-    },
-    /*
-     * Return false when the recipient phone matches the denied list.
-     *
-     * outgoing_deny_list is a comma separated list of strings. If a string in
-     * that list matches the beginning of the phone then we set up a response
-     * with a denied state. The pending message process will ignore these
-     * messages and those reports will be left without an auto-reply. The
-     * denied messages still show up in the messages export.
-     */
-    _isResponseAllowed: function(doc) {
-        var self = module.exports,
-            conf = self._getConfig('outgoing_deny_list') || '';
-        if (self._isMessageFromGateway(doc)) {
-            return false;
-        }
-        return _.every(conf.split(','), function(s) {
-            // ignore falsey inputs
-            if (!s || !doc.from) {
-                return true;
-            }
-            return !doc.from.match(
-                new RegExp('^' + utils.escapeRegex(s.trim()), 'i')
-            );
-        });
     },
     _isReportedAfterStartDate: function(doc) {
         var self = module.exports,
@@ -107,9 +70,6 @@ module.exports = {
                 phone: doc.from,
                 message: msg
             };
-        if (!self._isResponseAllowed(doc)) {
-            opts.state = 'denied';
-        }
         messages.addMessage(opts);
     },
     onMatch: function(change, db, audit, callback) {


### PR DESCRIPTION
Issue: https://github.com/medic/medic-webapp/issues/750

Outgoing deny list will now be applied to schedules and responses
generated on reports.  So instead of seeing `scheduled` or `pending`
state on a message you will see `denied`.

Moved `isOutgoingAllowed`, `_isMessageFromGateway` and related tests
into utils library so schedule creation and report validation and
response messages can make use of it.

Calling `messages.addMessage` or `uitls.addScheduledMessage` now
transparently checks the outgoing deny list and assigns a `denied` state
when appropriate.

I removed some odd logic in `addScheduledMessage` because it's not used
or documented anywhere and is error prone.  There was a check for
`doc.muted` field when creating a scheduled message.  I looked through
the code and fairly certain this property is not set or used by
anything.