### PR TITLE
disable transitions by default and harden configuration a bit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Disabled
 }
 ```
 
+```
+{
+  "transitions": {
+    "registrations": {
+      "disable": true
+    }
+  }
+}
+```
+
 ## Transitions API
 
 A transition does async processing of a document once per rev/change, and obeys

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ Develop      | Master
 
 Get node deps with  `npm install`.
 
+## Run
+
+`node server.js`
+
+Debug mode:
+
+`node server.js debug`
+
+## Run Tests
+
+`grunt test`
+
+
+## Overview
+
+Sentinel uses the changes feed on a CouchDB database and runs a set of
+transitions on a document.  It also manages some scheduled tasks like message
+schedules.
+
 ## Settings
 
 Export a `COUCH_URL` env variable so sentinel knows what database to use. e.g.
@@ -14,27 +33,61 @@ Export a `COUCH_URL` env variable so sentinel knows what database to use. e.g.
 export COUCH_URL='http://root:123qwe@localhost:5984/medic'
 ```
 
-Sentinel works with Medic Mobile and listens to changes on the database. It is 
-configured through the dashboard Medic Mobile app settings screen.
+Default settings values are in `defaults.js`.  On initial start, and when there
+are changes to the ddoc, sentinel reads `ddoc.app_setings` to determine configuration.
 
-Default settings values are in `defaults.js`.
+By default all transitions are disabled, to enable a transition modify the
+`transitions` property on `ddoc.app_settings`.
 
-## Run
+### Transitions Configuration Examples
 
-`node ./server.js`
+Enabled
 
-Debug mode:
+```
+{
+  "transitions": {
+    "registrations": true,
+    "default_responses": true,
+    "update_clinics": true
+  }
+}
+```
 
-`node ./server.js debug`
+```
+{
+  "transitions": {
+    "registrations": {
+      "param": "val"
+    },
+    "default_responses": {},
+    "update_clinics": {}
+  }
+}
+```
 
-## Run Tests
+Disabled
 
-`grunt test`
+```
+{
+  "transitions": {}
+}
+```
+
+```
+{
+  "transitions": {
+    "registrations": false
+  }
+}
+```
 
 ## Transitions API
 
 A transition does async processing of a document once per rev/change, and obeys
 the following rules:
+
+* has a `filter` function that determines if it needs to run/be applied to a
+  document.
 
 * accepts a document as a reference and makes changes using that reference,
   copying is discouraged.

--- a/defaults.js
+++ b/defaults.js
@@ -11,55 +11,7 @@ var defaults = {
     schedule_evening_hours: 23,
     schedule_evening_minutes: 0,
     synthetic_date: null,
-    transitions: {
-        accept_patient_reports: {
-            load: './transitions/accept_patient_reports.js'
-        },
-        conditional_alerts: {
-            load: './transitions/conditional_alerts.js'
-        },
-        default_responses: {
-            load: './transitions/default_responses.js'
-        },
-        update_sent_by: {
-            load: './transitions/update_sent_by.js'
-        },
-        ohw_counseling: {
-            disable: true,
-            load: './transitions/ohw_counseling.js'
-        },
-        ohw_emergency_report: {
-            disable: true,
-            load: './transitions/ohw_emergency_report.js'
-        },
-        ohw_notifications: {
-            disable: true,
-            load: './transitions/ohw_notifications.js'
-        },
-        resolve_pending: {
-            disable: true,
-            load: './transitions/resolve_pending.js'
-        },
-        registration: {
-            load: './transitions/registration.js'
-        },
-        twilio_message: {
-            disable: true,
-            load: './transitions/twilio_message.js'
-        },
-        update_clinics: {
-            load: './transitions/update_clinics.js'
-        },
-        update_notifications: {
-            load: './transitions/update_notifications.js'
-        },
-        update_scheduled_reports: {
-            load: './transitions/update_scheduled_reports.js'
-        },
-        update_sent_forms: {
-            load: './transitions/update_sent_forms.js'
-        }
-    },
+    transitions: {},
     loglevel: 'info'
 };
 

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -7,10 +7,9 @@ var _ = require('underscore'),
     transitions = {};
 
 /*
- * All transitions are disabled by default, add new ones here to make it
- * available to the configuration.  For security reasons, we want to avoid
- * doing a `require` based on a random input string, hence we maintain this
- * index of transitions.
+ * Add new transitions here to make them available for configuration.  For
+ * security reasons, we want to avoid doing a `require` based on random input,
+ * hence we maintain this index of transitions.
  */
 var availableTransitions = [
   'accept_patient_reports',


### PR DESCRIPTION
Support `disable` but ignore `load` setting, backwards compatible with
old style configuration.  

Issue: https://github.com/medic/medic-webapp/issues/2207