### PR TITLE
conditional_alerts fixes for 2.9

### DIFF
--- a/test/unit/conditional_alerts.js
+++ b/test/unit/conditional_alerts.js
@@ -222,7 +222,7 @@ exports['when recent form condition is true send message'] = function(test) {
 };
 
 exports['handle missing condition reference gracefully'] = function(test) {
-        
+
     sinon.stub(transition, '_getConfig').returns({
         '0': {
             form: 'STCK',
@@ -243,7 +243,7 @@ exports['handle missing condition reference gracefully'] = function(test) {
     };
     test.expect(2);
     transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
-        test.equals(err, 'Cannot read property \'s1_avail\' of undefined');
+        test.ok(err.match(/Cannot read property 's1_avail' of undefined/));
         test.equals(changed, false);
         test.done();
     });

--- a/transitions/conditional_alerts.js
+++ b/transitions/conditional_alerts.js
@@ -9,20 +9,11 @@ module.exports = {
     _getConfig: function() {
         return _.extend({}, config.get('alerts'));
     },
-    _hasConfig: function(doc) {
-        var self = module.exports;
-        // confirm the form is defined on a reminder config
-        return _.find(self._getConfig(), function(obj) {
-            return obj.form &&
-                doc.form.match(new RegExp('^\\s*'+obj.form+'\\s*$','i'));
-        });
-    },
     _runCondition: function(condition, context, callback) {
         try {
             callback(null, vm.runInNewContext(condition, context));
         } catch(e) {
-            var lines = e.message.split('\n');
-            callback(lines[lines.length - 1]);
+            callback(e.message);
         }
     },
     _evaluateCondition: function(doc, alert, callback) {
@@ -48,21 +39,11 @@ module.exports = {
             });
         }
     },
-    _hasRun: function(doc) {
-        return Boolean(
-            doc &&
-            doc.transitions &&
-            doc.transitions.conditional_alerts
-        );
-    },
     filter: function(doc) {
-        var self = module.exports;
         return Boolean(
             doc &&
             doc.form &&
-            doc.type === 'data_record' &&
-            self._hasConfig(doc) &&
-            !self._hasRun(doc)
+            doc.type === 'data_record'
         );
     },
     onMatch: function(change, db, audit, cb) {

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -118,6 +118,12 @@ var canRun = function(options) {
         if (doc.transitions && doc.transitions[key]) {
             return parseInt(doc._rev) === parseInt(doc.transitions[key].last_rev);
         }
+        logger.debug(
+            'isRevSame tested true on transition %s for seq %s doc %s',
+            key,
+            change.seq,
+            change.id
+        );
         return false;
     };
 
@@ -263,7 +269,7 @@ var applyTransitions = function(options, callback) {
         };
         if (!canRun(opts)) {
             logger.debug(
-                'not running transition %s for seq %s doc %s',
+                'canRun test failed on transition %s for seq %s doc %s',
                 key,
                 options.change.seq,
                 options.change.id

--- a/transitions/update_clinics.js
+++ b/transitions/update_clinics.js
@@ -55,7 +55,6 @@ module.exports = {
         );
     },
     onMatch: function(change, db, audit, callback) {
-        logger.debug('calling onMatch in transition' + __filename);
         var doc = change.doc,
             q = { include_docs: true, limit: 1 };
 

--- a/transitions/update_clinics.js
+++ b/transitions/update_clinics.js
@@ -20,7 +20,7 @@ var associateContact = function(audit, doc, contact, callback) {
         contact.phone = doc.from;
         audit.saveDoc(contact, function(err) {
             if (err) {
-                console.log('Error updating contact: ' + JSON.stringify(err, null, 2));
+                logger.error('Error updating contact: ' + JSON.stringify(err, null, 2));
                 return callback(err);
             }
             self.setContact(doc, contact, callback);


### PR DESCRIPTION
Applied the diff between conditional_alerts 0.4.x and 2.9.x branches. I'm not sure exactly why the _hasRun logic was removed in 0.4? I'm guessing there was a bug with that RegExp and certain form codes like द. I could not find anything in the git logs but it might be good to track down the history and apply all the changes to the 2.9 branch.  In particular I should check for tests.

Related Issues:
https://github.com/medic/medic-projects/issues/1133
https://github.com/medic/medic-webapp/issues/2978
