### PR TITLE
fix conditional alerts part deux

### DIFF
--- a/test/functional/transitions.js
+++ b/test/functional/transitions.js
@@ -64,7 +64,7 @@ exports['transitions are only executed again if first run failed'] = function(te
       form: 'V',
       recipient: 'reporting_unit',
       message: 'alert!',
-      condition: 'doc.fields.last_menstrual_period = 15'
+      condition: 'doc.fields.last_menstrual_period == 15'
     }
   });
   var saveDoc = sinon.stub();

--- a/test/functional/transitions.js
+++ b/test/functional/transitions.js
@@ -101,3 +101,57 @@ exports['transitions are only executed again if first run failed'] = function(te
     });
   });
 };
+
+exports['transitions are executed again when subsequent transitions succeed'] = function(test) {
+  configGet.withArgs('transitions').returns({
+    conditional_alerts: {},
+    default_responses: {},
+  });
+  configGet.withArgs('default_responses').returns({ start_date: '2010-01-01' });
+  configGet.withArgs('alerts').returns({
+    V: {
+      form: 'V',
+      recipient: 'reporting_unit',
+      message: 'alert!',
+      condition: 'doc.fields.last_menstrual_period == 15'
+    }
+  });
+  var saveDoc = sinon.stub();
+  saveDoc.callsArg(1);
+
+  transitions._loadTransitions();
+  var change1 = {
+    id: 'abc',
+    seq: '44',
+    doc: {
+      type: 'data_record',
+      form: 'V',
+      from: '123456798',
+      reported_date: new Date()
+    }
+  };
+  var audit = { saveDoc: saveDoc };
+  transitions.applyTransitions({ audit: audit, change: change1 }, function() {
+    test.equals(saveDoc.callCount, 1);
+    var saved = saveDoc.args[0][0].transitions;
+    test.equals(saved.default_responses.seq, '44');
+    test.equals(saved.default_responses.ok, true);
+
+    var doc = saveDoc.args[0][0];
+    doc.fields = { last_menstrual_period: 15 };
+    var change2 = {
+      id: 'abc',
+      seq: '45',
+      doc: doc
+    };
+    transitions.applyTransitions({ audit: audit, change: change2 }, function() {
+      test.equals(saveDoc.callCount, 2);
+      var saved2 = saveDoc.args[1][0].transitions;
+      test.equals(saved2.conditional_alerts.seq, '45');
+      test.equals(saved2.conditional_alerts.ok, true);
+      test.equals(saved2.default_responses.seq, '44');
+      test.equals(saved2.default_responses.ok, true);
+      test.done();
+    });
+  });
+};

--- a/test/functional/transitions.js
+++ b/test/functional/transitions.js
@@ -1,0 +1,103 @@
+var transitions = require('../../transitions/index'),
+    sinon = require('sinon'),
+    config = require('../../config'),
+    configGet;
+
+exports.setUp = function(callback) {
+  configGet = sinon.stub(config, 'get');
+  callback();
+};
+
+exports.tearDown = function(callback) {
+  if (config.get.restore) {
+    config.get.restore();
+  }
+  callback();
+};
+
+exports['transitions are only executed once if successful'] = function(test) {
+  configGet.withArgs('transitions').returns({ conditional_alerts: {} });
+  configGet.withArgs('alerts').returns({
+    V: {
+      form: 'V',
+      recipient: 'reporting_unit',
+      message: 'alert!',
+      condition: 'true'
+    }
+  });
+  var saveDoc = sinon.stub();
+  saveDoc.callsArg(1);
+
+  transitions._loadTransitions();
+  var change1 = {
+    id: 'abc',
+    seq: '44',
+    doc: {
+      type: 'data_record',
+      form: 'V'
+    }
+  };
+  var audit = { saveDoc: saveDoc };
+  transitions.applyTransitions({ audit: audit, change: change1 }, function() {
+    test.equals(saveDoc.callCount, 1);
+    var saved = saveDoc.args[0][0];
+    test.equals(saved.transitions.conditional_alerts.seq, '44');
+    test.equals(saved.transitions.conditional_alerts.ok, true);
+    test.equals(saved.tasks[0].messages[0].message, 'alert!');
+    var change2 = {
+      id: 'abc',
+      seq: '45',
+      doc: saveDoc.args[0][0]
+    };
+    transitions.applyTransitions({ audit: audit, change: change2 }, function() {
+      // not updated
+      test.equals(saveDoc.callCount, 1);
+      test.done();
+    });
+  });
+};
+
+exports['transitions are only executed again if first run failed'] = function(test) {
+  configGet.withArgs('transitions').returns({ conditional_alerts: {} });
+  configGet.withArgs('alerts').returns({
+    V: {
+      form: 'V',
+      recipient: 'reporting_unit',
+      message: 'alert!',
+      condition: 'doc.fields.last_menstrual_period = 15'
+    }
+  });
+  var saveDoc = sinon.stub();
+  saveDoc.callsArg(1);
+
+  transitions._loadTransitions();
+  var change1 = {
+    id: 'abc',
+    seq: '44',
+    doc: {
+      type: 'data_record',
+      form: 'V'
+    }
+  };
+  var audit = { saveDoc: saveDoc };
+  transitions.applyTransitions({ audit: audit, change: change1 }, function() {
+    // first run fails so no save
+    test.equals(saveDoc.callCount, 0);
+    var change2 = {
+      id: 'abc',
+      seq: '45',
+      doc: {
+        type: 'data_record',
+        form: 'V',
+        fields: { last_menstrual_period: 15 }
+      }
+    };
+    transitions.applyTransitions({ audit: audit, change: change2 }, function() {
+      test.equals(saveDoc.callCount, 1);
+      var saved2 = saveDoc.args[0][0].transitions;
+      test.equals(saved2.conditional_alerts.seq, '45');
+      test.equals(saved2.conditional_alerts.ok, true);
+      test.done();
+    });
+  });
+};

--- a/test/unit/conditional_alerts.js
+++ b/test/unit/conditional_alerts.js
@@ -222,7 +222,7 @@ exports['when recent form condition is true send message'] = function(test) {
 };
 
 exports['handle missing condition reference gracefully'] = function(test) {
-        
+
     sinon.stub(transition, '_getConfig').returns({
         '0': {
             form: 'STCK',
@@ -243,7 +243,7 @@ exports['handle missing condition reference gracefully'] = function(test) {
     };
     test.expect(2);
     transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
-        test.equals(err, 'Cannot read property \'s1_avail\' of undefined');
+        test.ok(err.match(/Cannot read property 's1_avail' of undefined/));
         test.equals(changed, false);
         test.done();
     });

--- a/test/unit/finalize-transition.js
+++ b/test/unit/finalize-transition.js
@@ -109,7 +109,7 @@ exports['applyTransition adds errors to doc but does not return errors'] = funct
     }, function(err, changed) {
         test.ok(!err);
         test.ok(!changed);
-        test.ok(doc.transitions.x.ok === false);
+        test.ok(_.isUndefined(doc.transitions)); // don't save the transition or it won't run next time
         test.ok(doc.errors.length === 1);
         // error message contains error
         test.ok(doc.errors[0].message.match(/oops/));

--- a/test/unit/finalize-transition.js
+++ b/test/unit/finalize-transition.js
@@ -85,8 +85,7 @@ exports['applyTransition creates transitions property'] = function(test) {
     });
 };
 
-exports['applyTransition handles errors'] = function(test) {
-    test.expect(5);
+exports['applyTransition adds errors to doc but does not return errors'] = function(test) {
     var doc = {
         _rev: '1'
     };
@@ -108,11 +107,9 @@ exports['applyTransition handles errors'] = function(test) {
         transition: transition,
         audit: audit
     }, function(err, changed) {
-        test.equals(err.message, 'oops');
-        test.equals(changed, undefined);
-        // ok is set to false
+        test.ok(!err);
+        test.ok(!changed);
         test.ok(doc.transitions.x.ok === false);
-        // one error is created on doc
         test.ok(doc.errors.length === 1);
         // error message contains error
         test.ok(doc.errors[0].message.match(/oops/));

--- a/transitions/conditional_alerts.js
+++ b/transitions/conditional_alerts.js
@@ -9,20 +9,11 @@ module.exports = {
     _getConfig: function() {
         return _.extend({}, config.get('alerts'));
     },
-    _hasConfig: function(doc) {
-        var self = module.exports;
-        // confirm the form is defined on a reminder config
-        return _.find(self._getConfig(), function(obj) {
-            return obj.form &&
-                doc.form.match(new RegExp('^\\s*'+obj.form+'\\s*$','i'));
-        });
-    },
     _runCondition: function(condition, context, callback) {
         try {
             callback(null, vm.runInNewContext(condition, context));
         } catch(e) {
-            var lines = e.message.split('\n');
-            callback(lines[lines.length - 1]);
+            callback(e.message);
         }
     },
     _evaluateCondition: function(doc, alert, callback) {
@@ -48,21 +39,11 @@ module.exports = {
             });
         }
     },
-    _hasRun: function(doc) {
-        return Boolean(
-            doc &&
-            doc.transitions &&
-            doc.transitions.conditional_alerts
-        );
-    },
     filter: function(doc) {
-        var self = module.exports;
         return Boolean(
             doc &&
             doc.form &&
-            doc.type === 'data_record' &&
-            self._hasConfig(doc) &&
-            !self._hasRun(doc)
+            doc.type === 'data_record'
         );
     },
     onMatch: function(change, db, audit, cb) {

--- a/transitions/conditional_alerts.js
+++ b/transitions/conditional_alerts.js
@@ -9,6 +9,15 @@ module.exports = {
     _getConfig: function() {
         return _.extend({}, config.get('alerts'));
     },
+    _hasRun: function(doc) {
+        // Avoid running forever. Also ignores the error state
+        // (doc.transitions.conditional_alerts.ok) of the previous run.
+        return Boolean(
+            doc &&
+            doc.transitions &&
+            doc.transitions.conditional_alerts
+        );
+    },
     _runCondition: function(condition, context, callback) {
         try {
             callback(null, vm.runInNewContext(condition, context));
@@ -40,10 +49,12 @@ module.exports = {
         }
     },
     filter: function(doc) {
+        var self = module.exports;
         return Boolean(
             doc &&
             doc.form &&
-            doc.type === 'data_record'
+            doc.type === 'data_record' &&
+            !self._hasRun(doc)
         );
     },
     onMatch: function(change, db, audit, cb) {

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -118,6 +118,12 @@ var canRun = function(options) {
         if (doc.transitions && doc.transitions[key]) {
             return parseInt(doc._rev) === parseInt(doc.transitions[key].last_rev);
         }
+        logger.debug(
+            'isRevSame tested true on transition %s for seq %s doc %s',
+            key,
+            change.seq,
+            change.id
+        );
         return false;
     };
 
@@ -263,7 +269,7 @@ var applyTransitions = function(options, callback) {
         };
         if (!canRun(opts)) {
             logger.debug(
-                'not running transition %s for seq %s doc %s',
+                'canRun test failed on transition %s for seq %s doc %s',
                 key,
                 options.change.seq,
                 options.change.id
@@ -277,7 +283,7 @@ var applyTransitions = function(options, callback) {
          */
         operations.push(function(cb) {
             applyTransition(opts, function(err, changed) {
-                cb(null, changed);
+                cb(null, err || changed);
             });
         });
     });

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -220,40 +220,33 @@ var applyTransition = function(options, callback) {
 
     /*
      * Transitions are async and should return true if the document has
-     * changed.  If a transition errors then log the error, but don't
-     * return it because that will stop the series and the other
-     * transitions won't run.
+     * changed.  If a transition errors then log the error, but don't return it
+     * because that will stop the series and the other transitions won't run.
      */
     transition.onMatch(change, db, audit, function(err, changed) {
         logger.debug(
-            'finished transition for doc %s seq %s transition %s',
-            change.id, change.seq, key
+            'finished transition %s for seq %s doc %s is %s',
+            key, change.seq, change.id, changed ? 'changed' : 'unchanged'
         );
-        // todo?
-        // prop = doc.transitions && doc.transitions[key] ? doc.transitions[key] : {};
-        //_setProperty('tries', prop.tries ? prop.tries++ : 1)
-        //_setProperty('couch', 'uuid');
-        //
         if (err || changed) {
             _setProperty('last_rev', parseInt(change.doc._rev) + 1);
             _setProperty('seq', change.seq);
             _setProperty('ok', !err);
         }
         if (err) {
-            var message = 'Transition error on ' + key;
-            if (err.message) {
-                message += ': ' + err.message;
-            }
+            // adds an error to the doc but it will only get saved if there are
+            // other changes too.
             utils.addError(change.doc, {
                 code: key + '_error',
-                message: message
+                message: 'Transition error on ' + key + ': ' +
+                    err.message ? err.message: JSON.stringify(err)
             });
             logger.error(
-                'transition %s returned error doc %s seq %s: %s',
+                'transition %s errored on doc %s seq %s: %s',
                 key, change.id, change.seq, JSON.stringify(err)
             );
         }
-        callback(err, changed);
+        callback(null, changed);
     });
 };
 
@@ -276,15 +269,8 @@ var applyTransitions = function(options, callback) {
             );
             return;
         }
-        /*
-         * Transition error short circuits async.series, so we never
-         * return errors on the callback but if there are errors we
-         * save them.
-         */
         operations.push(function(cb) {
-            applyTransition(opts, function(err, changed) {
-                cb(null, err || changed);
-            });
+            applyTransition(opts, cb);
         });
     });
 

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -277,7 +277,7 @@ var applyTransitions = function(options, callback) {
          */
         operations.push(function(cb) {
             applyTransition(opts, function(err, changed) {
-                cb(null, err || changed);
+                cb(null, changed);
             });
         });
     });

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -228,7 +228,7 @@ var applyTransition = function(options, callback) {
             'finished transition %s for seq %s doc %s is %s',
             key, change.seq, change.id, changed ? 'changed' : 'unchanged'
         );
-        if (err || changed) {
+        if (changed) {
             _setProperty('last_rev', parseInt(change.doc._rev) + 1);
             _setProperty('seq', change.seq);
             _setProperty('ok', !err);

--- a/transitions/update_clinics.js
+++ b/transitions/update_clinics.js
@@ -20,7 +20,7 @@ var associateContact = function(audit, doc, contact, callback) {
         contact.phone = doc.from;
         audit.saveDoc(contact, function(err) {
             if (err) {
-                console.log('Error updating contact: ' + JSON.stringify(err, null, 2));
+                logger.error('Error updating contact: ' + JSON.stringify(err, null, 2));
                 return callback(err);
             }
             self.setContact(doc, contact, callback);
@@ -55,7 +55,6 @@ module.exports = {
         );
     },
     onMatch: function(change, db, audit, callback) {
-        logger.debug('calling onMatch in transition' + __filename);
         var doc = change.doc,
             q = { include_docs: true, limit: 1 };
 


### PR DESCRIPTION
    fixed bug, don't short ciruit transitions if one errors.
    
    Do not return errors when applying transitions because that will short
    circuit async.series so transitions will stop being applied.
    
    Transitions are async and should return true if the document has
    changed.  If a transition errors then log the error, but don't return it
    because that will stop the series and the other transitions won't run.
    A doc can be modified with error messages but will only get saved to the
    doc if there are other (non-error) changes too.
    
    Some time ago errors messages were added to the doc because there was no
    way to surface parser errors.  Since the configuration in templates and
    conditionals/expressions involves evaluating code, it's useful to
    provide some clue to the user when this fails.  This isn't perfect but
    it's a middleground solution.

Related Issues:
https://github.com/medic/medic-projects/issues/1133
https://github.com/medic/medic-webapp/issues/2978
