### PR TITLE
Add date of birth if it exists

### DIFF
--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -84,12 +84,14 @@ exports['add_patient trigger creates a new patient'] = function(test) {
     var submitterId = 'papa';
     var patientId = '05649';
     var senderPhoneNumber = '+555123';
+    var dob = '2017-03-31T01:15:09.000Z';
     var change = { doc: {
         form: 'R',
         patient_id: patientId,
         reported_date: 53,
         from: senderPhoneNumber,
-        fields: { patient_name: patientName }
+        fields: { patient_name: patientName },
+        birth_date: dob
     } };
     // return expected view results when searching for people_by_phone
     var view = sinon.stub().callsArgWith(3, null, { rows: [ { doc: { parent: { _id: submitterId } } } ] });
@@ -117,6 +119,7 @@ exports['add_patient trigger creates a new patient'] = function(test) {
         test.equals(saveDoc.args[0][0].reported_date, 53);
         test.equals(saveDoc.args[0][0].type, 'person');
         test.equals(saveDoc.args[0][0].patient_id, patientId);
+        test.equals(saveDoc.args[0][0].date_of_birth, dob);
         test.done();
     });
 };

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -341,6 +341,10 @@ module.exports = {
                     type: 'person',
                     patient_id: patientId
                 };
+                // include the DOB if it was generated on report
+                if (doc.birth_date) {
+                  patient.date_of_birth = doc.birth_date;
+                }
                 audit.saveDoc(patient, callback);
             });
         });


### PR DESCRIPTION
The `birth_date` is generated by the `add_birth_date` trigger in this
transition and should be carried over to any new contacts that are
created by this same report.

*Missing tests*

Issue: https://github.com/medic/medic-webapp/issues/3100