### PR TITLE
Create a patient person if it doesn't exist medic/medic-webapp#3115

### DIFF
--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -313,17 +313,15 @@ module.exports = {
             patientId = doc.patient_id,
             patientNameField = _.first(options.params) || 'patient_name';
 
-        utils.getRegistrations({
-            db: db,
-            id: patientId
-        }, function(err, registrations) {
-            if (err) {
+        db.medic.get('patient-' + patientId, function(err, patientContact) {
+            if (err && err.statusCode !== 404) {
                 return callback(err);
             }
-            if (registrations.length) {
-                // patient already registered, no action required
+
+            if (patientContact) {
                 return callback();
             }
+
             db.medic.view('medic-client', 'people_by_phone', {
                 key: [ doc.from ],
                 include_docs: true


### PR DESCRIPTION
Instead of checking if there are any registrations for the patient,
check to see if the patient document exists that we're trying to create,
and if it doesn't create it.