### PR TITLE
3082 clear schedule from registration

### DIFF
--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -277,7 +277,7 @@ module.exports = {
             // Registration forms that clear schedules do so fully
             // silence_type will be split again later, so join them back
             options.report = {
-              silence_type: options.params.join(","),
+              silence_type: options.params.join(','),
               silence_for: null
             };
             module.exports.clearSchedule(options, cb);

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -297,7 +297,7 @@ module.exports = {
                 return callback(err);
             }
             config.messages.forEach(function(msg) {
-                if (!msg.event_type) {
+                if (!msg.event_type || msg.event_type === 'report_accepted') {
                     messages.addMessage({
                         doc: doc,
                         phone: messages.getRecipientPhone(doc, msg.recipient),

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -298,6 +298,13 @@ module.exports = {
             }
             config.messages.forEach(function(msg) {
                 if (msg.event_type !== 'registration_not_found') {
+                    messages.addMessage({
+                        doc: doc,
+                        phone: messages.getRecipientPhone(doc, msg.recipient),
+                        message: messages.getMessage(msg, locale),
+                        options: extra,
+                        registrations: registrations
+                    });
                 }
             });
             callback();

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -297,13 +297,8 @@ module.exports = {
                 return callback(err);
             }
             config.messages.forEach(function(msg) {
-                messages.addMessage({
-                    doc: doc,
-                    phone: messages.getRecipientPhone(doc, msg.recipient),
-                    message: messages.getMessage(msg, locale),
-                    options: extra,
-                    registrations: registrations
-                });
+                if (msg.event_type !== 'registration_not_found') {
+                }
             });
             callback();
         });

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -7,7 +7,7 @@ var vm = require('vm'),
     messages = require('../lib/messages'),
     validation = require('../lib/validation'),
     schedules = require('../lib/schedules'),
-    reports = require('./accept_patient_reports'),
+    acceptPatientReports = require('./accept_patient_reports'),
     ids = require('../lib/ids'),
     moment = require('moment'),
     config = require('../config'),
@@ -280,7 +280,7 @@ module.exports = {
               silence_type: options.params.join(','),
               silence_for: null
             };
-            module.exports.clearSchedule(options, cb);
+            acceptPatientReports.handleReport(options, cb);
         }
     },
     addMessages: function(db, config, doc, callback) {
@@ -297,7 +297,7 @@ module.exports = {
                 return callback(err);
             }
             config.messages.forEach(function(msg) {
-                if (msg.event_type !== 'registration_not_found') {
+                if (!msg.event_type) {
                     messages.addMessage({
                         doc: doc,
                         phone: messages.getRecipientPhone(doc, msg.recipient),
@@ -328,23 +328,6 @@ module.exports = {
                 callback();
             }
         );
-    },
-    clearSchedule: function(options, callback) {
-        var db = options.db,
-            doc = options.doc;
-            
-        utils.getRegistrations({
-            db: db,
-            id: doc.fields && doc.fields.patient_id
-        }, function(err, registrations) {
-            reports.matchRegistrations({
-                db: db,
-                audit: options.audit,
-                doc: doc,
-                registrations: registrations,
-                report: options.report
-            }, callback);
-        });
     },
     setId: function(options, callback) {
         var doc = options.doc,


### PR DESCRIPTION
Allow for registration reports to fully clear schedules. This way te config of a registration report does not need to be split between `registrations` and `accept_patient_reports` if it also needs to clear schedules. Having teh config and processing split caused multiple errors since in https://github.com/medic/medic-webapp/issues/3082.