### PR TITLE
Make error messages for metaData updates unique

### DIFF
--- a/transitions/index.js
+++ b/transitions/index.js
@@ -318,7 +318,7 @@ var getProcessedSeq = function(callback) {
 var updateMetaData = function(seq, callback) {
     getMetaData(function(err, metaData) {
         if (err) {
-            logger.error('Error updating metaData', err);
+            logger.error('Error fetching metaData for update', err);
             return callback();
         }
         metaData.processed_seq = seq;


### PR DESCRIPTION
Otherwise in minified code, you can't know which of the two distinct errors is
being generated.