### PR TITLE
Translate task schedule group titles

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -96,7 +96,8 @@ module.exports = {
                 message: template.render(msg.message, details),
                 group: msg.group,
                 phone: phone,
-                type: msg.type
+                type: msg.type,
+                translation_key: msg.translation_key
             });
         } catch(e) {
             utils.addError(doc, {

--- a/lib/schedules.js
+++ b/lib/schedules.js
@@ -124,7 +124,8 @@ module.exports = {
                     due: due.toISOString(),
                     message: message,
                     group: msg.group,
-                    type: schedule.name
+                    type: schedule.name,
+                    translation_key: schedule.translation_key
                 }, phone, registrations);
             } else {
                 // bad offset, skip this msg


### PR DESCRIPTION
Pass the group name translation_key from the configuration to the
generated tasks so the UI can display translated values.

medic/medic-webapp#3283