### PR TITLE
Correct trigger param parsing

### DIFF
--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -567,11 +567,32 @@ exports['trigger param configuration supports JSON as a string'] = function (tes
     });
 };
 
-exports['trigger param configuration parse failure propagates to the callbacks'] = function (test) {
+exports['trigger param configuration supports direct JSON'] = function (test) {
     var eventConfig = {
         form: 'R',
-        //                                                                  actual JSON not allowed!
         events: [ { name: 'on_create', trigger: 'testparamparsing', params: {foo: 'bar'} } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(options) {
+        test.deepEqual(options.params, {foo: 'bar'});
+
+        test.done();
+    });
+};
+
+exports['trigger param configuration parse failure for invalid JSON propagates to the callbacks'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        //                                                                                v missing end }
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: '{"foo": "bar"' } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
     };
 
     transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(err) {

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -498,3 +498,85 @@ exports['filter returns true for xforms reports'] = function(test) {
     test.equals(actual, true);
     test.done();
 };
+
+exports['trigger param configuration supports strings'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: 'foo' } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(options) {
+        test.deepEqual(options.params, ['foo']);
+
+        test.done();
+    });
+};
+
+exports['trigger param configuration supports comma-delimited strings as array'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: 'foo,bar' } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(options) {
+        test.deepEqual(options.params, ['foo', 'bar']);
+
+        test.done();
+    });
+};
+
+exports['trigger param configuration supports arrays as a string'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: '["foo","bar", 3]' } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(options) {
+        test.deepEqual(options.params, ['foo', 'bar', 3]);
+
+        test.done();
+    });
+};
+
+exports['trigger param configuration supports JSON as a string'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: '{"foo": "bar"}' } ]
+    };
+
+    transition.triggers.testparamparsing = function(options, cb) {
+        cb(options);
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(options) {
+        test.deepEqual(options.params, {foo: 'bar'});
+
+        test.done();
+    });
+};
+
+exports['trigger param configuration parse failure propagates to the callbacks'] = function (test) {
+    var eventConfig = {
+        form: 'R',
+        //                                                                  actual JSON not allowed!
+        events: [ { name: 'on_create', trigger: 'testparamparsing', params: {foo: 'bar'} } ]
+    };
+
+    transition.fireConfiguredTriggers({}, {}, eventConfig, {}, function(err) {
+        test.ok(err instanceof Error);
+
+        test.done();
+    });
+};


### PR DESCRIPTION
If `params` doesn't parse right we were just dropping the error (yay callbacks!). I've refactored the code so that the error can be passed back through the main callback correctly.

First commit is just the tests, second is the code what fixes it.

![image](https://cloud.githubusercontent.com/assets/583851/24370568/c21f0cd8-131f-11e7-96ac-ba53a7cb07f0.png)