### PR TITLE
Configure travis to build on latest nodejs and our min of 6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 sudo: false
-node_js: "6.10"
+node_js:
+  - "node"
+  - "6.5"
 
 before_script:
   - npm install grunt-cli -g

--- a/server.js
+++ b/server.js
@@ -26,8 +26,8 @@ const nodeVersionCheck = callback => {
       callback(new Error(`Node version ${major}.${minor}.${patch} is not supported`));
     }
 
-    if (major < 6 || ( major === 6 && minor < 10)) {
-      console.error('This node version may not be supported');
+    if (major < 6 || ( major === 6 && minor < 5)) {
+      console.error('We recommend nodejs 6.5 or higher.');
     }
 
     callback();


### PR DESCRIPTION
Tweak startup warning when not nodejs 6.5 or higher.

medic/medic-webapp#3421