### PR TITLE
Expose person to message formatter medic/medic-webapp#3419

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,6 +1,7 @@
 var _ = require('underscore'),
     template = require('./template'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    logger = require('./logger');
 
 function addMessage(opts) {
     var self = module.exports,
@@ -15,11 +16,19 @@ function addMessage(opts) {
         _.defaults(details, module.exports.extractDetails(opts.registrations[0].doc));
     }
 
+    if (opts.person) {
+        details.person = opts.person;
+    }
+
     if (!utils.isOutgoingAllowed(doc.from)) {
         opts.state = 'denied';
     }
 
     if (phone && opts.message) {
+        if (logger.level === 'debug') {
+            logger.debug(`Adding message: ${opts.message}`);
+            logger.debug(`With: ${details}`);
+        }
         try {
             utils.addMessage(doc, {
                 phone: String(phone),

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -18,6 +18,12 @@ function addMessage(opts) {
 
     if (opts.person) {
         details.person = opts.person;
+
+        // For backwards compatibilty. Configurers are used to the patient's
+        // name being available here, so alias it for now. This could be dropped
+        // in a future major release if we ever decide to revisit and
+        // standardise how we expose data to the message templater.
+        details.patient_name = details.patient_name || details.person.name;
     }
 
     if (!utils.isOutgoingAllowed(doc.from)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -478,6 +478,32 @@ module.exports = {
     });
   },
   /*
+   * Given a patient "shortcode" (as used in SMS reports), return the
+   * patient's person record
+   */
+  getPatientContact: (db, patientShortcodeId, callback) => {
+    db.medic.view('medic', 'patient_by_patient_shortcode_id',
+      {
+        key: patientShortcodeId,
+        include_docs: true
+      },
+      (err, results) => {
+        if (err) {
+          return callback(err);
+        }
+
+        if (!results.rows.length) {
+          return callback();
+        }
+
+        if (results.rows.length > 1) {
+          console.warn('More than one patient person document for shortcode ' + patientShortcodeId);
+        }
+
+        return callback(null, results.rows[0].doc);
+    });
+  },
+  /*
    * Used to avoid infinite loops of auto-reply messages between gateway and
    * itself.
    */

--- a/test/functional/schedules.js
+++ b/test/functional/schedules.js
@@ -71,6 +71,7 @@ exports['registration sets up schedule'] = function(test) {
             }
         ]
     }]);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
@@ -169,6 +170,7 @@ exports['registration sets up schedule using translation_key'] = function(test) 
             recipient: 'reporting_unit'
         }]
     });
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
     sinon.stub(utils, 'translate')
         .withArgs('thanks', 'en').returns('thanks {{contact.name}}')
@@ -248,6 +250,7 @@ exports['registration sets up schedule using bool_expr'] = function(test) {
             }
         ]
     }]);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
@@ -342,6 +345,7 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
             }
         ]
     }]);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [ { doc: { fields: { patient_name: 'barry' } } } ]);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
@@ -442,6 +446,7 @@ exports['no schedule using false bool_expr'] = function(test) {
         ]
     }]);
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
         start_from: 'reported_date',

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -234,6 +234,38 @@ exports['addMessage template supports fields'] = function(test) {
     test.done();
 };
 
+exports['addMessage lets you use info from a passed person'] = test => {
+    const doc = {};
+    messages.addMessage({
+        doc: doc,
+        phone: '123',
+        person: {name: 'Sally'},
+        message: 'Thank you {{person.name}}.',
+    });
+    test.equals(doc.tasks.length, 1);
+    test.equals(
+        doc.tasks[0].messages[0].message,
+        'Thank you Sally.'
+    );
+    test.done();
+};
+
+exports['addMessage aliases person.name to patient_name for backwards compat'] = test => {
+    const doc = {};
+    messages.addMessage({
+        doc: doc,
+        phone: '123',
+        person: {name: 'Sally'},
+        message: 'Thank you {{patient_name}}.',
+    });
+    test.equals(doc.tasks.length, 1);
+    test.equals(
+        doc.tasks[0].messages[0].message,
+        'Thank you Sally.'
+    );
+    test.done();
+};
+
 exports['getRecipientPhone resolves `clinic` correctly'] = function(test) {
     var phone = '+13125551213';
     var doc = {

--- a/test/unit/patient_registration.js
+++ b/test/unit/patient_registration.js
@@ -212,6 +212,7 @@ exports['valid form adds patient_id and patient document'] = function(test) {
 exports['registration sets up responses'] = function(test) {
 
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(2);
 
@@ -274,6 +275,7 @@ exports['registration sets up responses'] = function(test) {
 exports['registration responses support locale'] = function(test) {
 
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(2);
 


### PR DESCRIPTION
Allow registration messages to use data from the person contact, e.g.
person.name. This is better than using data from previous registrations
as patients who are created through the UI may not have the same
previous registrations as users created through SMS. However, all
patients have person contacts.

medic/medic-webapp#3419