### PR TITLE
Support both tests and prod medic/medic-webapp#3630

### DIFF
--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -266,7 +266,8 @@ const requiredFunctions = {
   onMatch: 4,
   filter: 1
 };
-transitions._AVAILABLE_TRANSITIONS.forEach(name => {
+
+transitions.availableTransitions().forEach(name => {
   const transition = require(`../../transitions/${name}`);
   Object.keys(requiredFunctions).forEach(key => {
     exports[`Checking ${key} signature for ${name} transition`] = test => {

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -125,9 +125,7 @@ const loadTransitions = (autoEnableSystemTransitions = true) => {
       return logger.warn(`transition ${transition} is disabled`);
     }
 
-    // Needed to support tests mocking out _loadTransition, and _loadTransition
-    // not being available in prod.
-    (self._loadTransition || self.loadTransition)(transition);
+    self._loadTransition(transition);
   });
 
   // Warn if there are configured transitions that are not available
@@ -381,19 +379,22 @@ const attach = () => {
   });
 };
 
+const availableTransitions = () => {
+  return AVAILABLE_TRANSITIONS;
+};
+
 module.exports = {
+  _loadTransition: loadTransition,
+  _changeQueue: changeQueue,
+  availableTransitions: availableTransitions,
   loadTransitions: loadTransitions,
   canRun: canRun,
   attach: attach,
   finalize: finalize,
   applyTransition: applyTransition,
-  applyTransitions: applyTransitions
+  applyTransitions: applyTransitions,
 };
 
-if (process.env.TEST_ENV) {
-  module.exports._loadTransition = loadTransition;
-  module.exports._changeQueue = changeQueue;
-  module.exports._AVAILABLE_TRANSITIONS = AVAILABLE_TRANSITIONS;
-} else {
+if (!process.env.TEST_ENV) {
   loadTransitions();
 }

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -125,7 +125,9 @@ const loadTransitions = (autoEnableSystemTransitions = true) => {
       return logger.warn(`transition ${transition} is disabled`);
     }
 
-    self._loadTransition(transition);
+    // Needed to support tests mocking out _loadTransition, and _loadTransition
+    // not being available in prod.
+    (self._loadTransition || self.loadTransition)(transition);
   });
 
   // Warn if there are configured transitions that are not available


### PR DESCRIPTION
# Description

Recent changes broke prod because _loadTransition is not available

medic/medic-webapp#3630

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [x] Webapp CI runs clean against this branch 
