### PR TITLE
Adds init function to validate transitions

### DIFF
--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -83,12 +83,12 @@ exports['filter validation hasRun'] = test => {
 
 const testConfigIsValid = (test, alert) => {
   sinon.stub(config, 'get').returns([alert]);
-  transition.onMatch({ doc: doc }, null, null, (err, docNeedsSaving) => {
+  try {
+    transition.init();
+  } catch(e) {
     test.equals(config.get.getCall(0).args[0], 'multi_form_alerts');
-    test.ok(!docNeedsSaving);
-    test.ok(err);
     test.done();
-  });
+  }
 };
 
 exports['validates config : isReportCounted'] = test => {

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -140,7 +140,11 @@ const loadTransitions = (autoEnableSystemTransitions = true) => {
 const loadTransition = key => {
   try {
     logger.info(`loading transition ${key}`);
-    transitions[key] = require('./' + key);
+    const transition = require('./' + key);
+    if (transition.init) {
+      transition.init();
+    }
+    transitions[key] = transition;
   } catch(e) {
     logger.error(`failed loading transition ${key}`);
     logger.error(e);

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -6,7 +6,14 @@ const vm = require('vm'),
       messages = require('../lib/messages'),
       utils = require('../lib/utils'),
       transitionUtils = require('./utils'),
-      NAME = 'multi_form_alerts';
+      NAME = 'multi_form_alerts',
+      requiredFields = [
+        'isReportCounted',
+        'numReportsThreshold',
+        'message',
+        'recipients',
+        'timeWindowInDays'
+      ];
 
 const getAlertConfig = () => config.get('multi_form_alerts');
 
@@ -39,7 +46,7 @@ const countReports = (reports, isReportCountedString) => {
   return reports.filter((report) => {
     const context = { report: report, latestReport: reports[0]};
     try {
-      return vm.runInNewContext('(' + isReportCountedString + ')(report, latestReport)', context);
+      return vm.runInNewContext(`(${isReportCountedString})(report, latestReport)`, context);
     } catch(err) {
       logger.error(`Could not eval "isReportCounted" function for (report=${context.report._id}, latestReport=${context.latestReport._id}` +
         `). Report will not be counted. Function passed: "${isReportCountedString}". Error: ${err.message}`);
@@ -125,33 +132,33 @@ const getPhonesWithDuplicates = (recipients, countedReports) => {
   return getPhonesOneRecipient(recipients, countedReports);
 };
 
-const validateConfig = (alert) => {
-  if (!alert.isReportCounted ||
-      !alert.numReportsThreshold ||
-      !alert.message ||
-      !alert.recipients ||
-      !alert.timeWindowInDays) {
-    throw new Error(`Bad config for multi_form_alerts. Expecting fields isReportCounted, ` +
-      `numReportsThreshold, message, recipients, timeWindowInDays. Found ${JSON.stringify(alert)}`);
-  }
-  alert.timeWindowInDays = parseInt(alert.timeWindowInDays);
-  if (isNaN(alert.timeWindowInDays)) {
-    throw new Error('Bad config for multi_form_alerts. Expecting "timeWindowInDays" to be an integer. ' +
-      'E.g "timeWindowInDays": "3"');
-  }
-  alert.numReportsThreshold = parseInt(alert.numReportsThreshold);
-  if (isNaN(alert.numReportsThreshold)) {
-    throw new Error('Bad config for multi_form_alerts. Expecting "numReportsThreshold" to be an integer. ' +
-      'E.g "numReportsThreshold": "3"');
-  }
-  if(!_.isArray(alert.recipients)) {
-    throw new Error('Bad config for multi_form_alerts. Expecting "recipients" to be an array of strings. ' +
-      'E.g "recipients": ["+9779841452277", "countedReports[0].contact.phone"]');
-  }
-  if (alert.forms && (!_.isArray(alert.forms))) {
-    alert.forms = null;
-    logger.warn('Bad config for multi_form_alerts. Expecting "forms" to be an array of form codes. Continuing without "forms", since it\'s optional.');
-  }
+const validateConfig = () => {
+  const alertConfig = getAlertConfig();
+  alertConfig.forEach(alert => {
+    requiredFields.forEach(field => {
+      if (!alert[field]) {
+        throw new Error(`Bad config for multi_form_alerts. Expecting fields: ${requiredFields.join(', ')}`);
+      }
+    });
+    alert.timeWindowInDays = parseInt(alert.timeWindowInDays);
+    if (isNaN(alert.timeWindowInDays)) {
+      throw new Error('Bad config for multi_form_alerts. Expecting "timeWindowInDays" to be an integer. ' +
+        'E.g "timeWindowInDays": "3"');
+    }
+    alert.numReportsThreshold = parseInt(alert.numReportsThreshold);
+    if (isNaN(alert.numReportsThreshold)) {
+      throw new Error('Bad config for multi_form_alerts. Expecting "numReportsThreshold" to be an integer. ' +
+        'E.g "numReportsThreshold": "3"');
+    }
+    if(!_.isArray(alert.recipients)) {
+      throw new Error('Bad config for multi_form_alerts. Expecting "recipients" to be an array of strings. ' +
+        'E.g "recipients": ["+9779841452277", "countedReports[0].contact.phone"]');
+    }
+    if (alert.forms && (!_.isArray(alert.forms))) {
+      alert.forms = null;
+      logger.warn('Bad config for multi_form_alerts. Expecting "forms" to be an array of form codes. Continuing without "forms", since it\'s optional.');
+    }
+  });
 };
 
 /* Return true if the doc has been changed. */
@@ -178,9 +185,8 @@ const onMatch = (change, db, audit, callback) => {
   const errors = [];
   let docNeedsSaving = false;
   let promiseSeries = Promise.resolve();
-  alertConfig.forEach((alert) => {
+  alertConfig.forEach(alert => {
     promiseSeries = promiseSeries.then(() => {
-      validateConfig(alert);
       return runOneAlert(alert, latestReport)
         .then((isDocChangedByOneAlert) => {
           docNeedsSaving = docNeedsSaving || isDocChangedByOneAlert;
@@ -208,5 +214,6 @@ module.exports = {
     doc.type === 'data_record' &&
     !transitionUtils.hasRun(doc, NAME)
   ),
-  onMatch: onMatch
+  onMatch: onMatch,
+  init: validateConfig
 };

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -134,31 +134,34 @@ const getPhonesWithDuplicates = (recipients, countedReports) => {
 
 const validateConfig = () => {
   const alertConfig = getAlertConfig();
-  alertConfig.forEach(alert => {
+  const errors = [];
+  alertConfig.forEach((alert, idx) => {
     requiredFields.forEach(field => {
       if (!alert[field]) {
-        throw new Error(`Bad config for multi_form_alerts. Expecting fields: ${requiredFields.join(', ')}`);
+        errors.push(`Alert number ${idx}, expecting fields: ${requiredFields.join(', ')}`);
       }
     });
     alert.timeWindowInDays = parseInt(alert.timeWindowInDays);
     if (isNaN(alert.timeWindowInDays)) {
-      throw new Error('Bad config for multi_form_alerts. Expecting "timeWindowInDays" to be an integer. ' +
-        'E.g "timeWindowInDays": "3"');
+      errors.push(`Alert number ${idx}, expecting "timeWindowInDays" to be an integer, eg: "timeWindowInDays": "3"`);
     }
     alert.numReportsThreshold = parseInt(alert.numReportsThreshold);
     if (isNaN(alert.numReportsThreshold)) {
-      throw new Error('Bad config for multi_form_alerts. Expecting "numReportsThreshold" to be an integer. ' +
-        'E.g "numReportsThreshold": "3"');
+      errors.push(`Alert number ${idx}, expecting "numReportsThreshold" to be an integer, eg: "numReportsThreshold": "3"`);
     }
     if(!_.isArray(alert.recipients)) {
-      throw new Error('Bad config for multi_form_alerts. Expecting "recipients" to be an array of strings. ' +
-        'E.g "recipients": ["+9779841452277", "countedReports[0].contact.phone"]');
+      errors.push(`Alert number ${idx}, expecting "recipients" to be an array of strings, eg: "recipients": ["+9779841452277", "countedReports[0].contact.phone"]`);
     }
     if (alert.forms && (!_.isArray(alert.forms))) {
       alert.forms = null;
-      logger.warn('Bad config for multi_form_alerts. Expecting "forms" to be an array of form codes. Continuing without "forms", since it\'s optional.');
+      logger.warn(`Bad config for ${NAME}, alert number ${idx}. Expecting "forms" to be an array of form codes. Continuing without "forms", since it\'s optional.`);
     }
   });
+  if (errors.length) {
+    logger.error(`Validation failed for ${NAME} transition`);
+    logger.error(errors.join('\n'));
+    throw new Error(`Validation failed for ${NAME} transition`);
+  }
 };
 
 /* Return true if the doc has been changed. */


### PR DESCRIPTION
# Description

If this optional function is exported by the transition it's
called when the transition is loaded. Transition goading occurs
on start and on configuration change.

If the init function throws an error then the transition isn't
loaded, the error message is logged, and the other transitions
load as per usual.

medic/medic-webapp#3585

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
