### PR TITLE
Multi form alerts transition performance

### DIFF
--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -83,8 +83,75 @@ const fetchHydratedDoc = id => {
   });
 };
 
+const findRow = (rows, id) => id && rows.find(row => row.id === id);
+
+const collectContactIds = docs => {
+  const ids = [];
+  docs.forEach(doc => {
+    const contactId = doc.contact && doc.contact._id;
+    if (contactId && ids.indexOf(contactId) === -1) {
+      ids.push(contactId);
+    }
+    let parent = doc.parent;
+    while (parent) {
+      if (parent._id && ids.indexOf(parent._id) === -1) {
+        ids.push(parent._id);
+      }
+      parent = parent.parent;
+    }
+  });
+  return ids;
+};
+
+const hydrateDocs = docs => {
+  const ids = collectContactIds(docs);
+  if (!ids.length) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    db.medic.fetch({ keys: ids }, (err, results) => {
+      if (err) {
+        return reject(err);
+      }
+      const rows = results.rows;
+      docs.forEach(doc => {
+        const row = findRow(rows, doc.contact && doc.contact._id);
+        if (row && row.doc) {
+          doc.contact = row.doc;
+        }
+        let parent = doc;
+        while (parent) {
+          const row = findRow(rows, parent.parent && parent.parent._id);
+          if (row && row.doc) {
+            parent.parent = row.doc;
+          }
+          parent = parent.parent;
+        }
+      });
+      resolve();
+    });
+  });
+};
+
 module.exports = {
+  /**
+   * Given a doc id get a doc and all parents and contacts
+   * @param id The id of the doc
+   * @returns Promise
+   */
   fetchHydratedDoc: fetchHydratedDoc,
+
+  /**
+   * Given an array of minified docs bind the parents and contacts
+   * @param docs The array of docs to hydrate
+   * @returns Promise
+   */
+  hydrateDocs: hydrateDocs,
+
+  /**
+   * Remove all fields except for parent and _id from parents and contacts.
+   * @param doc The doc to minify
+   */
   minify: doc => {
     if (!doc) {
       return;

--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -89,12 +89,12 @@ const collectContactIds = docs => {
   const ids = [];
   docs.forEach(doc => {
     const contactId = doc.contact && doc.contact._id;
-    if (contactId && ids.indexOf(contactId) === -1) {
+    if (contactId && !ids.includes(contactId)) {
       ids.push(contactId);
     }
     let parent = doc.parent;
     while (parent) {
-      if (parent._id && ids.indexOf(parent._id) === -1) {
+      if (parent._id && !ids.includes(parent._id)) {
         ids.push(parent._id);
       }
       parent = parent.parent;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -223,28 +223,23 @@ const getReportsWithSameClinicAndForm = (options, callback) => {
   );
 };
 
-const getReportsWithinTimeWindow = (latestTimestamp, timeWindowInDays) => {
-  var timeWindowInMillis = moment.duration({'days' : timeWindowInDays}).asMilliseconds();
+const getReportsWithinTimeWindow = (latestTimestamp, timeWindowInDays, options = {}) => {
+  const timeWindowInMillis = moment.duration({'days' : timeWindowInDays}).asMilliseconds();
   const startTimestamp = latestTimestamp - timeWindowInMillis;
+  _.defaults(options, {
+    endkey: [startTimestamp],
+    startkey: [latestTimestamp],
+    include_docs: true,
+    descending: true // most recent first
+  });
   return new Promise((resolve, reject) => {
-    db.medic.view(
-      'medic-client',
-      'reports_by_date',
-      {
-        endkey: [startTimestamp],
-        startkey: [latestTimestamp],
-        include_docs: true,
-        descending: true // most recent first
-      },
-      (err, data) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data.rows.map(row => row.doc));
-        }
+    db.medic.view('medic-client', 'reports_by_date', options, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data.rows.map(row => row.doc));
       }
-    );
-
+    });
   });
 };
 

--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -17,9 +17,9 @@ exports.setUp = callback => {
   // reset alert
   alert = {
     isReportCounted: 'function() { return true; }',
-    numReportsThreshold : 3,
-    message : 'hi',
-    recipients : ['+254777888999'],
+    numReportsThreshold: 3,
+    message: 'hi',
+    recipients: ['+254777888999'],
     timeWindowInDays : 7
   };
   callback();
@@ -133,9 +133,9 @@ exports['filters reports by form if forms is present in config'] = test => {
 };
 
 exports['if not enough reports pass the isReportCounted func, does nothing'] = test => {
+  alert.isReportCounted = 'function() { return false; }';
   sinon.stub(config, 'get').returns([alert]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
-  alert.isReportCounted = 'function() { return false; }';
   stubFetchHydratedDocs();
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -19,19 +19,7 @@ const fetchReports = (latestTimestamp, timeWindowInDays, formTypes) => {
       }
       return reports;
     })
-    .then(hydrateDocs);
-};
-
-const hydrateDocs = (docs) => {
-  return docs.reduce(function(promise, doc) {
-    return promise.then((fetchedDocs) => {
-      return lineage.fetchHydratedDoc(doc._id)
-        .then(fetchedDoc => {
-          fetchedDocs.push(fetchedDoc);
-          return fetchedDocs;
-        });
-    });
-  }, Promise.resolve([]));
+    .then(lineage.hydrateDocs);
 };
 
 const countReports = (reports, isReportCountedString) => {


### PR DESCRIPTION
# Description

Makes three performance improvements to the multi-form-alerts transition.

Firstly, docs are hydrated in one batch fetch from the database instead of
serially one at a time.

Secondly, the Script it parsed once per execution rather than once per report.
This could be further improved by parsing and caching once per configuration
change if necessary.

Thirdly, the report fetch is batched so we don't request too many docs in one
go.

medic/medic-webapp#3631

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
