### PR TITLE
3635 multi form alerts analytics

### DIFF
--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -104,9 +104,12 @@ const collectContactIds = docs => {
 };
 
 const hydrateDocs = docs => {
+  if (!docs.length) {
+    return Promise.resolve([]);
+  }
   const ids = collectContactIds(docs);
   if (!ids.length) {
-    return Promise.resolve();
+    return Promise.resolve(docs);
   }
   return new Promise((resolve, reject) => {
     db.medic.fetch({ keys: ids }, (err, results) => {
@@ -114,7 +117,9 @@ const hydrateDocs = docs => {
         return reject(err);
       }
       const rows = results.rows;
-      docs.forEach(doc => {
+
+      const hydratedDocs = JSON.parse(JSON.stringify(docs));
+      hydratedDocs.forEach(doc => {
         const row = findRow(rows, doc.contact && doc.contact._id);
         if (row && row.doc) {
           doc.contact = row.doc;
@@ -128,7 +133,7 @@ const hydrateDocs = docs => {
           parent = parent.parent;
         }
       });
-      resolve();
+      resolve(hydratedDocs);
     });
   });
 };

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -3,50 +3,69 @@ var _ = require('underscore'),
     utils = require('./utils'),
     logger = require('./logger');
 
+/**
+ * Expected opts :
+ * - doc
+ * - message : template for the message
+ * - phone (optional, will get clinic phone if absent)
+ * - templateContext (optional)
+ * - registrations (optional)
+ * - person (optional)
+ * - state (optional)
+ * All other fields are ignored.
+ */
 function addMessage(opts) {
     var self = module.exports,
         doc = opts.doc,
-        details = module.exports.extractDetails(doc),
+        templateContext = module.exports.extractTemplateContext(doc),
         phone = opts.phone || self.getRecipientPhone(doc, 'clinic');
 
-    if (opts.options) {
-        _.defaults(details, opts.options);
+    if (!phone) {
+        logger.debug(`Can't add message, no phone number found in opts: ${opts}`);
+        return;
+    }
+
+    if (!opts.message) {
+        logger.debug(`Can't add message, no message template found in opts: ${opts}`);
+        return;
+    }
+
+    if (opts.templateContext) {
+        _.defaults(templateContext, opts.templateContext);
     }
     if (opts.registrations && opts.registrations.length) {
-        _.defaults(details, module.exports.extractDetails(opts.registrations[0].doc));
+        _.defaults(templateContext, module.exports.extractTemplateContext(opts.registrations[0].doc));
     }
 
     if (opts.person) {
-        details.person = opts.person;
+        templateContext.person = opts.person;
 
         // For backwards compatibilty. Configurers are used to the patient's
         // name being available here, so alias it for now. This could be dropped
         // in a future major release if we ever decide to revisit and
         // standardise how we expose data to the message templater.
-        details.patient_name = details.patient_name || details.person.name;
+        templateContext.patient_name = templateContext.patient_name || templateContext.person.name;
     }
 
     if (!utils.isOutgoingAllowed(doc.from)) {
         opts.state = 'denied';
     }
 
-    if (phone && opts.message) {
-        if (logger.level === 'debug') {
-            logger.debug(`Adding message: ${opts.message}`);
-            logger.debug(`With: ${details}`);
-        }
-        try {
-            utils.addMessage(doc, {
-                phone: String(phone),
-                message: template.render(opts.message, details),
-                state: opts.state
-            });
-        } catch(e) {
-            utils.addError(doc, {
-                message: e.message + ': ' + opts.message,
-                code: 'parse_error'
-            });
-        }
+    if (logger.level === 'debug') {
+        logger.debug(`Adding message: ${opts.message}`);
+        logger.debug(`With: ${templateContext}`);
+    }
+    try {
+        utils.addMessage(doc, {
+            phone: String(phone),
+            message: template.render(opts.message, templateContext),
+            state: opts.state
+        });
+    } catch(e) {
+        utils.addError(doc, {
+            message: e.message + ': ' + opts.message,
+            code: 'parse_error'
+        });
     }
 }
 
@@ -86,7 +105,7 @@ module.exports = {
      * Provide some extra template context, internal fields always override
      * doc/form fields.
      */
-    extractDetails: function(doc) {
+    extractTemplateContext: function(doc) {
         var clinic = utils.getClinic(doc);
         var internal = {
             contact: clinic && clinic.contact,
@@ -99,16 +118,16 @@ module.exports = {
         return _.defaults(internal, doc.fields, doc);
     },
     scheduleMessage: function(doc, msg, phone, registrations) {
-        var details = module.exports.extractDetails(doc);
+        var templateContext = module.exports.extractTemplateContext(doc);
         if (registrations && registrations.length) {
-            _.defaults(details, module.exports.extractDetails(registrations[0].doc));
+            _.defaults(templateContext, module.exports.extractTemplateContext(registrations[0].doc));
         }
         phone = phone ? String(phone) : phone;
 
         try {
             utils.addScheduledMessage(doc, {
                 due: msg.due,
-                message: template.render(msg.message, details),
+                message: template.render(msg.message, templateContext),
                 group: msg.group,
                 phone: phone,
                 type: msg.type,
@@ -159,7 +178,7 @@ module.exports = {
             doc: doc,
             message: message,
             phone: self.getRecipientPhone(doc, 'grandparent_phone'),
-            options: options
+            templateContext: options
         });
     },
     notifyParent: function(doc, message, options) {
@@ -168,7 +187,7 @@ module.exports = {
             doc: doc,
             message: message,
             phone: self.getRecipientPhone(doc, 'parent_phone'),
-            options: options
+            templateContext: options
         });
     },
     addReply: function(doc, message, options) {
@@ -177,7 +196,7 @@ module.exports = {
             doc: doc,
             message: message,
             phone: self.getRecipientPhone(doc, 'clinic'),
-            options: options
+            templateContext: options
         });
     },
     addErrors: function(doc, errors) {
@@ -205,7 +224,7 @@ module.exports = {
         // support mustache template syntax in error messages
         try {
             error.message = template.render(
-                error.message, module.exports.extractDetails(doc)
+                error.message, module.exports.extractTemplateContext(doc)
             );
             utils.addError(doc, error);
         } catch(e) {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -12,6 +12,7 @@ var _ = require('underscore'),
  * - registrations (optional)
  * - person (optional)
  * - state (optional)
+ * - taskFields (optional)
  * All other fields are ignored.
  */
 function addMessage(opts) {
@@ -47,20 +48,19 @@ function addMessage(opts) {
         templateContext.patient_name = templateContext.patient_name || templateContext.person.name;
     }
 
-    if (!utils.isOutgoingAllowed(doc.from)) {
-        opts.state = 'denied';
-    }
+    let outputOpts = {
+        phone: String(phone),
+        message: template.render(opts.message, templateContext),
+        state: utils.isOutgoingAllowed(doc.from) ? opts.state : 'denied'
+    };
+
+    _.defaults(outputOpts, opts.taskFields);
 
     if (logger.level === 'debug') {
-        logger.debug(`Adding message: ${opts.message}`);
-        logger.debug(`With: ${templateContext}`);
+        logger.debug(`Adding message: ${outputOpts}`);
     }
     try {
-        utils.addMessage(doc, {
-            phone: String(phone),
-            message: template.render(opts.message, templateContext),
-            state: opts.state
-        });
+        utils.addMessage(doc, outputOpts);
     } catch(e) {
         utils.addError(doc, {
             message: e.message + ': ' + opts.message,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,6 +145,15 @@ const createTaskMessages = options => {
   return [ result ];
 };
 
+/**
+ * Options used:
+ *  - phone
+ *  - message
+ *  - state (optional)
+ * Options filtered out and ignored:
+ *  - 'uuid'
+ * All other options will be added as-is to the task object.
+ */
 const addMessage = (doc, options) => {
   options = options || {};
 

--- a/test/unit/default_responses.js
+++ b/test/unit/default_responses.js
@@ -370,28 +370,3 @@ exports['add response when recipient is allowed'] = function (test) {
         test.done();
     });
 };
-
-exports['add response with denied state when recipient is denied'] = function (test) {
-    sinon.stub(utils, 'isOutgoingAllowed').returns(false);
-    sinon.stub(config, 'getTranslations').returns({
-        en: { sms_received: 'ahoy mate' }
-    });
-    var messageFn = sinon.spy(messages, 'addMessage');
-    test.expect(4);
-    var doc = {
-        from: 'x',
-        type: 'data_record'
-    };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
-        test.ok(messageFn.calledOnce);
-        test.ok(messageFn.calledWith({
-            doc: doc,
-            phone: 'x',
-            message: 'ahoy mate',
-            state: 'denied'
-        }));
-        test.equals(err, null);
-        test.equals(changed, true);
-        test.done();
-    });
-};

--- a/test/unit/lineage.js
+++ b/test/unit/lineage.js
@@ -466,7 +466,7 @@ exports['hydrate+minify is noop on a place'] = test => {
 exports['hydrateDocs binds contacts and parents'] = test => {
   const docs = [
     { _id: 'a', contact: { _id: 'b' }, parent: { _id: 'c', parent: { _id: 'e' }} },
-    { _id: 'a', parent: { _id: 'd', parent: { _id: 'e' }} },
+    { _id: 'a2', parent: { _id: 'd', parent: { _id: 'e' }} },
   ];
   const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [
     { id: 'b', doc: { _id: 'b', name: 'barney' } },
@@ -474,14 +474,33 @@ exports['hydrateDocs binds contacts and parents'] = test => {
     { id: 'd', doc: { _id: 'd', name: 'donny', parent: { _id: 'e' } } },
     { id: 'e', doc: { _id: 'e', name: 'eric' } }
   ] });
-  lineage.hydrateDocs(docs).then(() => {
-    test.equals(docs[0].contact.name, 'barney');
-    test.equals(docs[0].parent.name, null);
-    test.equals(docs[0].parent.parent.name, 'eric');
-    test.equals(docs[1].parent.name, 'donny');
-    test.equals(docs[1].parent.parent.name, 'eric');
+  lineage.hydrateDocs(docs).then((hydratedDocs) => {
+    test.equals(hydratedDocs[0].contact.name, 'barney');
+    test.equals(hydratedDocs[0].parent.name, null);
+    test.equals(hydratedDocs[0].parent.parent.name, 'eric');
+    test.equals(hydratedDocs[1].parent.name, 'donny');
+    test.equals(hydratedDocs[1].parent.parent.name, 'eric');
     test.equals(fetch.callCount, 1);
     test.deepEqual(fetch.args[0][0].keys, [ 'b', 'c', 'e', 'd' ]);
+    test.done();
+  });
+};
+
+exports['hydrateDocs works on empty array'] = test => {
+  const docs = [];
+  lineage.hydrateDocs(docs).then((hydratedDocs) => {
+    test.equals(hydratedDocs.length, 0);
+    test.done();
+  });
+};
+
+exports['hydrateDocs works on docs without contacts or parents'] = test => {
+  const docs = [
+    { _id: 'a' },
+    { _id: 'b' },
+  ];
+  lineage.hydrateDocs(docs).then((hydratedDocs) => {
+    test.deepEqual(hydratedDocs, docs);
     test.done();
   });
 };

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -10,7 +10,7 @@ exports.tearDown = function(callback) {
     callback();
 };
 
-exports['extractDetails supports template variables on doc'] = function(test) {
+exports['extractTemplateContext supports template variables on doc'] = function(test) {
     var doc = {
         form: 'x',
         reported_date: '2050-03-13T13:06:22.002Z',
@@ -24,13 +24,13 @@ exports['extractDetails supports template variables on doc'] = function(test) {
             }
         }
     };
-    var details = messages.extractDetails(doc);
-    test.equals(details.contact.phone, '123');
-    test.equals(details.governor, 'arnold');
+    var templateContext = messages.extractTemplateContext(doc);
+    test.equals(templateContext.contact.phone, '123');
+    test.equals(templateContext.governor, 'arnold');
     test.done();
 };
 
-exports['extractDetails internal fields always override form fields'] = function(test) {
+exports['extractTemplateContext internal fields always override form fields'] = function(test) {
     var doc = {
         form: 'x',
         reported_date: '2050-03-13T13:06:22.002Z',
@@ -44,9 +44,9 @@ exports['extractDetails internal fields always override form fields'] = function
             }
         }
     };
-    var details = messages.extractDetails(doc);
-    test.equals(details.chw_name, 'Arnold');
-    test.equals(details.contact.name, 'Sally');
+    var templateContext = messages.extractTemplateContext(doc);
+    test.equals(templateContext.chw_name, 'Arnold');
+    test.equals(templateContext.contact.name, 'Sally');
     test.done();
 };
 

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -625,7 +625,7 @@ exports['addMessage prepops and passes the right information to messages.addMess
             doc: testDoc,
             phone: testPhone,
             message: testMessage,
-            options: { next_msg: { minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0 } },
+            templateContext: { next_msg: { minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0 } },
             registrations: testRegistration,
             person: testPerson
         };

--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -168,7 +168,7 @@ const assertMessage = (test, messageArgs, recipient, message) => {
     doc: doc,
     phone: recipient,
     message: message,
-    options: { countedReports: [doc, ...hydratedReports] }
+    templateContext: { countedReports: [doc, ...hydratedReports] }
   });
 };
 

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -57,7 +57,7 @@ const generateMessages = (recipients, messageTemplate, countedReports) => {
       doc: countedReports[0],
       phone: phone,
       message: messageTemplate,
-      options: {countedReports: countedReports}
+      templateContext: {countedReports: countedReports}
     });
     isLatestReportChanged = true;
   });

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -344,7 +344,7 @@ module.exports = {
                         doc: doc,
                         phone: messages.getRecipientPhone(doc, msg.recipient),
                         message: messages.getMessage(msg, locale),
-                        options: extra,
+                        templateContext: extra,
                         registrations: registrations,
                         person: person
                     });


### PR DESCRIPTION
# Description

When `multi_form_alert` is triggered, we generate alert messages on the `data_record`. Add fields on the corresponding `task` to make these alerts differentiable by analytics : `type:alert`, `alert_name`, and `countedReports`.

Note that `countedReports[0]` is the uuid of current report, and `countedReports[1..end]` are the uuids of the reports counted towards the alert threshold, sorted by submission date, most recent first.

medic/medic-webapp#3635

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
