### PR TITLE
Stops processing changes if config is invalid

### DIFF
--- a/config.js
+++ b/config.js
@@ -29,13 +29,7 @@ const initFeed = () => {
   feed.on('change', change => {
     if (change.id === '_design/medic') {
       logger.info('Reloading configuration');
-      initConfig(err => {
-        if (err) {
-          console.error('Error loading configuration. Exiting...');
-          process.exit(0);
-        }
-        require('./transitions').loadTransitions();
-      });
+      initConfig();
     } else if (change.id.startsWith('messages-')) {
       logger.info('Detected translations change - reloading');
       loadTranslations();
@@ -44,10 +38,11 @@ const initFeed = () => {
   feed.follow();
 };
 
-const initConfig = callback => {
+const initConfig = () => {
   db.medic.get(SETTINGS_PATH, (err, data) => {
     if (err) {
-      return callback(err);
+      console.error('Error loading configuration. Exiting...');
+      process.exit(0);
     }
     _.defaults(data.settings, defaults);
     config = data.settings;
@@ -58,7 +53,7 @@ const initConfig = callback => {
       config.schedule_evening_hours,
       config.schedule_evening_minutes
     );
-    callback();
+    require('./transitions').loadTransitions();
   });
 };
 
@@ -71,9 +66,9 @@ module.exports = {
   getTranslations: () => {
     return translations;
   },
-  init: callback => {
+  init: () => {
     initFeed();
     loadTranslations();
-    initConfig(callback);
+    initConfig();
   }
 };

--- a/server.js
+++ b/server.js
@@ -52,8 +52,6 @@ async.series([
     logger.transports.Console.level = config.get('loglevel');
     logger.debug('loglevel is %s.', logger.transports.Console.level);
   }
-  logger.info('attaching transitions...');
-  require('./transitions').attach();
   require('./schedule').checkSchedule();
   logger.info('startup complete.');
 });


### PR DESCRIPTION
# Description

Transitions now run validation via the `init` function on start up
and config change. If any transition init throws an Error then no
further changes will be processed but processing will resume once
the configuration is fixed.

medic/medic-webapp#3668

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
