### PR TITLE
Batching multi_form_alerts' getPhones and generateMessages

### DIFF
--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -178,7 +178,8 @@ const assertMessage = (test, messageArgs, recipient, message, alertName, numRepo
     phone: recipient,
     message: message,
     templateContext: {
-      countedReports: [doc, ...hydratedReports],
+      newReports: [doc, ...hydratedReports],
+      numCountedReports: [doc, ...hydratedReports].length,
       alertName: alertName,
       numReportsThreshold: numReportsThreshold,
       timeWindowInDays: timeWindowInDays
@@ -310,6 +311,69 @@ exports['does not add message when recipient is not international phone number']
   transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
     test.equals(messages.addMessage.getCalls().length, 0);
     test.equals(messages.addError.getCalls().length, 3); // 3 countedReports, one failed recipient each
+
+    test.ok(docNeedsSaving);
+    test.done();
+  });
+};
+
+exports['message only contains newReports'] = test => {
+  sinon.stub(config, 'get').returns([alert]);
+
+  const reportsWithOneAlreadyMessaged = [
+    { _id: 'docA', form: 'A', contact: { _id: 'contactA' } },
+    { _id: 'docB', form: 'B', contact: { _id: 'contactB' },
+      tasks: [
+        {
+          type: 'alert',
+          alert_name: alert.name,
+          countedReports: []
+        }
+      ]
+    },
+  ];
+  sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reportsWithOneAlreadyMessaged));
+
+  const hydratedReportsWithOneAlreadyMessaged = [
+    { _id: 'docA', form: 'A', contact: { _id: 'contactA', phone: '+234567'} },
+    {
+      _id: 'docB', form: 'B', contact: { _id: 'contactB', phone: '+345678'},
+      tasks: [
+        {
+          type: 'alert',
+          alert_name: alert.name,
+          countedReports: []
+        }
+      ]
+    }
+  ];
+  sinon.stub(lineage, 'hydrateDocs').returns(Promise.resolve(hydratedReportsWithOneAlreadyMessaged));
+
+  sinon.stub(messages, 'addError');
+  sinon.stub(messages, 'addMessage');
+
+  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+    test.equals(messages.addMessage.getCalls().length, 1);
+    test.equals(messages.addError.getCalls().length, 0);
+
+    const expected = {
+      doc: doc,
+      phone: alert.recipients[0],
+      message: alert.message,
+      templateContext: {
+        newReports: [doc, hydratedReportsWithOneAlreadyMessaged[0] ],
+        numCountedReports: [doc, ...hydratedReportsWithOneAlreadyMessaged].length,
+        alertName: alert.name,
+        numReportsThreshold: alert.numReportsThreshold,
+        timeWindowInDays: alert.timeWindowInDays
+      },
+      taskFields: {
+        type: 'alert',
+        alert_name: alert.name,
+        countedReports: [ doc._id, hydratedReportsWithOneAlreadyMessaged[0]._id, hydratedReportsWithOneAlreadyMessaged[1]._id ]
+      }
+    };
+    test.deepEqual(messages.addMessage.getCall(0).args[0], expected);
 
     test.ok(docNeedsSaving);
     test.done();

--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -117,11 +117,6 @@ exports['validates config : timeWindowInDays'] = test => {
   testConfigIsValid(test, [_.omit(alert, 'timeWindowInDays')]);
 };
 
-exports['validates config : timeWindowInDays < 100'] = test => {
-  alert.timeWindowInDays = 101;
-  testConfigIsValid(test, [ alert ]);
-};
-
 exports['fetches reports within time window'] = test => {
   sinon.stub(config, 'get').returns([alert]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));

--- a/test/unit/transitions/multi_form_alerts.js
+++ b/test/unit/transitions/multi_form_alerts.js
@@ -117,6 +117,11 @@ exports['validates config : timeWindowInDays'] = test => {
   testConfigIsValid(test, [_.omit(alert, 'timeWindowInDays')]);
 };
 
+exports['validates config : timeWindowInDays < 100'] = test => {
+  alert.timeWindowInDays = 101;
+  testConfigIsValid(test, [ alert ]);
+};
+
 exports['fetches reports within time window'] = test => {
   sinon.stub(config, 'get').returns([alert]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -44,21 +44,27 @@ const countReports = (reports, latestReport, script) => {
   });
 };
 
-const generateMessages = (alert, phones, countedReports) => {
+/** Has this report already been SMSed about for this alert? */
+const isReportAlreadyMessaged = (report, alertName) => {
+  return report.tasks && report.tasks.filter(task => task.alert_name === alertName).length;
+};
+
+const generateMessages = (alert, phones, latestReport, countedReportsIds, newReports) => {
   let isLatestReportChanged = false;
   phones.forEach((phone) => {
     if (phone.error) {
       logger.error(phone.error);
-      messages.addError(countedReports[0], phone.error);
+      messages.addError(latestReport, phone.error);
       isLatestReportChanged = true;
       return;
     }
     messages.addMessage({
-      doc: countedReports[0],
+      doc: latestReport,
       phone: phone,
       message: alert.message,
       templateContext: {
-        countedReports: countedReports,
+        newReports: newReports,
+        numCountedReports: countedReportsIds.length,
         alertName: alert.name,
         numReportsThreshold: alert.numReportsThreshold,
         timeWindowInDays: alert.timeWindowInDays
@@ -66,7 +72,7 @@ const generateMessages = (alert, phones, countedReports) => {
       taskFields: {
         type: 'alert',
         alert_name: alert.name,
-        countedReports: countedReports.map(report => report._id)
+        countedReports: countedReportsIds
       }
     });
     isLatestReportChanged = true;
@@ -80,53 +86,62 @@ const generateMessages = (alert, phones, countedReports) => {
 //    'countedReport.contact.parent.parent.contact.phone',   // returns string
 //    'countedReport.contact.parent.parent.alertRecipients', // returns string array
 // ]
-const getPhones = (recipients, countedReport) => {
-  return _.uniq(getPhonesWithDuplicates(recipients, countedReport));
+const getPhones = (recipients, reports) => {
+  let phones = [];
+  reports.forEach(report => {
+    const phonesForReport = getPhonesOneReport(recipients, report);
+    phones = phones.concat(phonesForReport);
+  });
+  phones = _.uniq(phones);
+  return phones;
 };
 
-const getPhonesWithDuplicates = (recipients, countedReport) => {
-  const getPhonesOneRecipient = (recipient, countedReport) => {
-    if (!recipient) {
-      return [];
-    }
-
-    if (/^\+[0-9]+$/.exec(recipient)) {
-      return [recipient];
-    }
-
-    const context = { countedReport: countedReport };
-    try {
-      const evaled = vm.runInNewContext(recipient, context);
-      if (_.isString(evaled)) {
-        return [evaled];
-      }
-      if (_.isArray(evaled)) {
-        return evaled.map((shouldBeAString) => {
-          if (!_.isString(shouldBeAString)) {
-            return { error: `multi_form_alerts : one of the phone numbers for "${recipient}"` +
-              ` is not a string. Message will not be sent. Found : ${JSON.stringify(shouldBeAString)}` };
-          }
-          return shouldBeAString;
-        });
-      }
-      return { error: `multi_form_alerts : phone number for "${recipient}"` +
-        ` is not a string or array of strings. Message will not be sent. Found: "${JSON.stringify(evaled)}"` };
-    } catch(err) {
-      return { error: `multi_form_alerts : Could not find a phone number for "${recipient}". ` +
-        `Message will not be sent. Error: "${err.message}"` };
-    }
-  };
-
+const getPhonesOneReport = (recipients, report) => {
   if (!recipients) {
     return [];
   }
 
+  let phones;
   if (_.isArray(recipients)) {
-    return _.flatten(
-      recipients.map(_.partial(getPhonesOneRecipient, _, countedReport)));
+    phones = _.flatten(
+      recipients.map(_.partial(getPhonesOneReportOneRecipientWithDuplicates, _, report)));
+  } else {
+    phones = getPhonesOneReportOneRecipientWithDuplicates(recipients, report);
   }
 
-  return getPhonesOneRecipient(recipients, countedReport);
+  return _.uniq(phones);
+};
+
+const getPhonesOneReportOneRecipientWithDuplicates = (recipient, countedReport) => {
+  if (!recipient) {
+    return [];
+  }
+
+  if (/^\+[0-9]+$/.exec(recipient)) {
+    return [recipient];
+  }
+
+  const context = { countedReport: countedReport };
+  try {
+    const evaled = vm.runInNewContext(recipient, context);
+    if (_.isString(evaled)) {
+      return [evaled];
+    }
+    if (_.isArray(evaled)) {
+      return evaled.map((shouldBeAString) => {
+        if (!_.isString(shouldBeAString)) {
+          return { error: `multi_form_alerts : one of the phone numbers for "${recipient}"` +
+            ` is not a string. Message will not be sent. Found : ${JSON.stringify(shouldBeAString)}` };
+        }
+        return shouldBeAString;
+      });
+    }
+    return { error: `multi_form_alerts : phone number for "${recipient}"` +
+      ` is not a string or array of strings. Message will not be sent. Found: "${JSON.stringify(evaled)}"` };
+  } catch(err) {
+    return { error: `multi_form_alerts : Could not find a phone number for "${recipient}". ` +
+      `Message will not be sent. Error: "${err.message}"` };
+  }
 };
 
 const validateConfig = () => {
@@ -168,19 +183,21 @@ const validateConfig = () => {
 };
 
 /**
- * Returns { countedReports, phones }.
+ * Returns { countedReportsIds, newReports, phones }.
  */
 const getCountedReportsAndPhones = (alert, latestReport) => {
   return new Promise((resolve, reject) => {
     const script = vm.createScript(`(${alert.isReportCounted})(report, latestReport)`);
     let skip = 0;
-    let countedReports = [];
-    let phones = [];
+    let countedReportsIds = [ latestReport._id ];
+    let newReports = [ latestReport ];
+    let phones = [ ...getPhonesOneReport(alert.recipients, latestReport) ];
     async.doWhilst(
       callback => {
         getCountedReportsAndPhonesBatch(script, latestReport, alert, skip)
           .then(output => {
-            countedReports = countedReports.concat(output.countedReports);
+            countedReportsIds = countedReportsIds.concat(output.countedReportsIds);
+            newReports = newReports.concat(output.newReports);
             phones = phones.concat(output.phones);
             callback(null, output.numFetched);
           })
@@ -194,30 +211,32 @@ const getCountedReportsAndPhones = (alert, latestReport) => {
         if (err) {
           return reject(err);
         }
-        resolve({ countedReports: countedReports, phones: _.uniq(phones) });
+        resolve({ countedReportsIds: countedReportsIds, newReports: newReports, phones: _.uniq(phones) });
       }
     );
   });
 };
 
 /**
- * Returns Promise({ numFetched, countedReports, phones }) for the db batch with skip value.
+ * Returns Promise({ numFetched, countedReportsIds, newReports, phones }) for the db batch with skip value.
  */
 const getCountedReportsAndPhonesBatch = (script, latestReport, alert, skip) => {
   const options = { skip: skip, limit: BATCH_SIZE };
-  const output = { countedReports: [ latestReport ] };
+  const output = {};
+  let countedReports;
   return fetchReports(latestReport.reported_date - 1, alert.timeWindowInDays, alert.forms, options)
     .then(fetched => {
       output.numFetched = fetched.length;
-      output.countedReports = output.countedReports.concat(countReports(fetched, latestReport, script));
+      countedReports = countReports(fetched, latestReport, script);
+      output.countedReportsIds = countedReports.map(report => report._id);
+      return countedReports;
     })
-    .then(() => {
-      output.phones = [];
-      output.countedReports.forEach(countedReport => {
-        const phonesForReport = getPhones(alert.recipients, countedReport);
-        output.phones = output.phones.concat(phonesForReport);
-      });
-      output.phones = _.uniq(output.phones);
+    .then(counted => {
+      output.newReports = counted.filter(report => !isReportAlreadyMessaged(report, alert.name));
+      return output.newReports;
+    })
+    .then((newReports) => {
+      output.phones = getPhones(alert.recipients, newReports);
       return output;
     });
 };
@@ -228,8 +247,8 @@ const runOneAlert = (alert, latestReport) => {
     return Promise.resolve(false);
   }
   return getCountedReportsAndPhones(alert, latestReport).then(output => {
-    if (output.countedReports.length >= alert.numReportsThreshold) {
-      return generateMessages(alert, output.phones, output.countedReports);
+    if (output.countedReportsIds.length >= alert.numReportsThreshold) {
+      return generateMessages(alert, output.phones, latestReport, output.countedReportsIds, output.newReports);
     }
     return false;
   });

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -9,7 +9,6 @@ const vm = require('vm'),
       transitionUtils = require('./utils'),
       TRANSITION_NAME = 'multi_form_alerts',
       BATCH_SIZE = 100,
-      MAX_TIME_WINDOW = 100,
       requiredFields = [
         'isReportCounted',
         'name',
@@ -157,9 +156,6 @@ const validateConfig = () => {
     alert.timeWindowInDays = parseInt(alert.timeWindowInDays);
     if (isNaN(alert.timeWindowInDays)) {
       errors.push(`Alert "${alert.name}", expecting "timeWindowInDays" to be an integer, eg: "timeWindowInDays": "3"`);
-    }
-    if (alert.timeWindowInDays > MAX_TIME_WINDOW) {
-      errors.push(`Alert "${alert.name}", "timeWindowInDays" should be less than {{MAX_TIME_WINDOW}}. Found: {{alert.timeWindowInDays}}`);
     }
     alert.numReportsThreshold = parseInt(alert.numReportsThreshold);
     if (isNaN(alert.numReportsThreshold)) {

--- a/transitions/multi_form_alerts.js
+++ b/transitions/multi_form_alerts.js
@@ -9,6 +9,7 @@ const vm = require('vm'),
       transitionUtils = require('./utils'),
       TRANSITION_NAME = 'multi_form_alerts',
       BATCH_SIZE = 100,
+      MAX_TIME_WINDOW = 100,
       requiredFields = [
         'isReportCounted',
         'name',
@@ -156,6 +157,9 @@ const validateConfig = () => {
     alert.timeWindowInDays = parseInt(alert.timeWindowInDays);
     if (isNaN(alert.timeWindowInDays)) {
       errors.push(`Alert "${alert.name}", expecting "timeWindowInDays" to be an integer, eg: "timeWindowInDays": "3"`);
+    }
+    if (alert.timeWindowInDays > MAX_TIME_WINDOW) {
+      errors.push(`Alert "${alert.name}", "timeWindowInDays" should be less than {{MAX_TIME_WINDOW}}. Found: {{alert.timeWindowInDays}}`);
     }
     alert.numReportsThreshold = parseInt(alert.numReportsThreshold);
     if (isNaN(alert.numReportsThreshold)) {


### PR DESCRIPTION
# Description

Convert getPhones processing to use batches of reports in multi_form_alerts, to avoid overly big sets of records.
Limit the available information for generateMessages, to avoid memory problems. Only message about newReports that haven't been messaged about before.

medic/medic-webapp#3678

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
