### PR TITLE
Add limit of 100 for num_reports_threshold in multi_report_alerts. 

### DIFF
--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -105,6 +105,11 @@ exports['validates config : num_reports_threshold'] = test => {
   testConfigIsValid(test, [_.omit(alert, 'num_reports_threshold')]);
 };
 
+exports['validates config : num_reports_threshold < 100'] = test => {
+  alert.num_reports_threshold = 100000000; // arbitrary large number
+  testConfigIsValid(test, [ alert ]);
+};
+
 exports['validates config : message'] = test => {
   testConfigIsValid(test, [_.omit(alert, 'message')]);
 };

--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -107,7 +107,7 @@ exports['validates config : num_reports_threshold'] = test => {
 
 exports['validates config : num_reports_threshold < 100'] = test => {
   alert.num_reports_threshold = 100000000; // arbitrary large number
-  testConfigIsValid(test, [ alert ]);
+  assertConfigIsInvalid(test, [ alert ]);
 };
 
 exports['validates config : message'] = test => {

--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -79,7 +79,7 @@ exports['filter validation hasRun'] = test => {
   test.done();
 };
 
-const testConfigIsValid = (test, alerts) => {
+const assertConfigIsInvalid = (test, alerts) => {
   sinon.stub(config, 'get').returns(alerts);
   try {
     transition.init();
@@ -90,19 +90,19 @@ const testConfigIsValid = (test, alerts) => {
 };
 
 exports['validates config : is_report_counted'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'is_report_counted')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'is_report_counted')]);
 };
 
 exports['validates config : name'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'name')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'name')]);
 };
 
 exports['validates config : names are unique'] = test => {
-  testConfigIsValid(test, [alert, alert]);
+  assertConfigIsInvalid(test, [alert, alert]);
 };
 
 exports['validates config : num_reports_threshold'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'num_reports_threshold')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'num_reports_threshold')]);
 };
 
 exports['validates config : num_reports_threshold < 100'] = test => {
@@ -111,15 +111,15 @@ exports['validates config : num_reports_threshold < 100'] = test => {
 };
 
 exports['validates config : message'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'message')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'message')]);
 };
 
 exports['validates config : recipients'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'recipients')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'recipients')]);
 };
 
 exports['validates config : time_window_in_days'] = test => {
-  testConfigIsValid(test, [_.omit(alert, 'time_window_in_days')]);
+  assertConfigIsInvalid(test, [_.omit(alert, 'time_window_in_days')]);
 };
 
 exports['fetches reports within time window'] = test => {

--- a/transitions/multi_report_alerts.js
+++ b/transitions/multi_report_alerts.js
@@ -7,6 +7,7 @@ const vm = require('vm'),
       messages = require('../lib/messages'),
       utils = require('../lib/utils'),
       transitionUtils = require('./utils'),
+      MAX_NUM_REPORTS_THRESHOLD = 100,
       TRANSITION_NAME = 'multi_report_alerts',
       BATCH_SIZE = 100,
       requiredFields = [
@@ -161,6 +162,9 @@ const validateConfig = () => {
     alert.num_reports_threshold = parseInt(alert.num_reports_threshold);
     if (isNaN(alert.num_reports_threshold)) {
       errors.push(`Alert "${alert.name}", expecting "num_reports_threshold" to be an integer, eg: "num_reports_threshold": "3"`);
+    }
+    if (alert.num_reports_threshold > MAX_NUM_REPORTS_THRESHOLD) {
+      errors.push(`Alert "${alert.name}", "num_reports_threshold" should be less than ${MAX_NUM_REPORTS_THRESHOLD}. Found ${alert.num_reports_threshold}`);
     }
     if(!_.isArray(alert.recipients)) {
       errors.push(`Alert "${alert.name}", expecting "recipients" to be an array of strings, eg: "recipients": ["+9779841452277", "countedReports[0].contact.phone"]`);


### PR DESCRIPTION

# Description

If num_reports_threshold gets too big we could get some memory problems when generating messages for the alert. 100 is really conservative.
medic/medic-webapp#3725

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
