### PR TITLE
Accept report when patient is found

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -34,6 +34,11 @@ function addMessage(opts) {
     if (opts.templateContext) {
         _.defaults(templateContext, opts.templateContext);
     }
+
+    if (opts.patient) {
+        _.defaults(templateContext, module.exports.extractTemplateContext(opts.patient));
+    }
+
     if (opts.registrations && opts.registrations.length) {
         _.defaults(templateContext, module.exports.extractTemplateContext(opts.registrations[0].doc));
     }

--- a/test/unit/accept_patient_reports.js
+++ b/test/unit/accept_patient_reports.js
@@ -35,7 +35,7 @@ exports['onMatch with matching form calls getRegistrations and then matchRegistr
     sinon.stub(transition, 'getAcceptedReports').returns([ { form: 'x' }, { form: 'z' } ]);
 
     var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []),
-        getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'}),
+        getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, { _id: 'uuid', name: 'sally' }),
         matchRegistrations = sinon.stub(transition, 'matchRegistrations').callsArgWith(1, null, true);
 
     transition.onMatch({
@@ -47,9 +47,9 @@ exports['onMatch with matching form calls getRegistrations and then matchRegistr
         test.equal(complete, true);
 
         test.equal(getRegistrations.called, true);
-        test.equal(getPatientContactUuid.called, true);
-        test.equal(getPatientContactUuid.callCount, 1);
-        test.equal(getPatientContactUuid.args[0][1], 'x');
+        test.equal(getPatientContact.called, true);
+        test.equal(getPatientContact.callCount, 1);
+        test.equal(getPatientContact.args[0][1], 'x');
         test.equal(matchRegistrations.called, true);
 
         test.done();
@@ -59,7 +59,7 @@ exports['onMatch with matching form calls getRegistrations and then matchRegistr
 exports['onMatch with no patient id adds error msg and response'] = function(test) {
     sinon.stub(transition, 'getAcceptedReports').returns([ { form: 'x' }, { form: 'z' } ]);
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2);
     sinon.stub(transition, 'matchRegistrations').callsArgWith(1, null, true);
 
     var doc = {
@@ -106,7 +106,7 @@ exports['matchRegistrations with no registrations does not error'] = function(te
     });
 };
 
-exports['matchRegistrations with registrations adds reply'] = function(test) {
+exports['matchRegistrations with patient adds reply'] = function(test) {
     var doc = {
         fields: { patient_id: '559' },
         contact: {
@@ -122,9 +122,7 @@ exports['matchRegistrations with registrations adds reply'] = function(test) {
     };
 
     transition.matchRegistrations({
-        registrations: [{
-            doc: { fields: { patient_name: 'Archibald' } }
-        }],
+        patient: { patient_name: 'Archibald' },
         doc: doc,
         report: {
             messages: [{
@@ -146,9 +144,8 @@ exports['matchRegistrations with registrations adds reply'] = function(test) {
     });
 };
 
-
 exports['adding silence_type to matchRegistrations calls silenceReminders'] = function(test) {
-    sinon.stub(transition, 'silenceReminders').callsArgWith(1, null);
+    sinon.stub(transition, 'silenceReminders').callsArgWith(1);
 
     transition.matchRegistrations({
         doc: { _id: 'a' },


### PR DESCRIPTION
# Description

Previously we only accepted the report and replied when a
registration was found. This doesn't work when patients are
created in the webapp as this happens without a registration
report being submitted.

This change makes the transition check for the patient contact by
the given shortcode instead.

medic/medic-webapp#3740

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
