### PR TITLE
Store code when adding errors

### DIFF
--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -207,7 +207,10 @@ exports['add_patient errors if the configuration doesnt point to an id'] = test 
 
   transition.onMatch(change, db, audit, () => {
     test.equal(doc.patient_id, undefined);
-    test.deepEqual(doc.errors, [{message: 'messages.generic.no_provided_patient_id', code: 'invalid_report'}]);
+    test.deepEqual(doc.errors, [{
+      message: 'messages.generic.no_provided_patient_id',
+      code: 'no_provided_patient_id'
+    }]);
     test.done();
   });
 };
@@ -247,7 +250,10 @@ exports['add_patient errors if the given id is not unique'] = test => {
 
   transition.onMatch(change, db, audit, () => {
     test.equal(doc.patient_id, undefined);
-    test.deepEqual(doc.errors, [{message: 'messages.generic.provided_patient_id_not_unique', code: 'invalid_report'}]);
+    test.deepEqual(doc.errors, [{
+      message: 'messages.generic.provided_patient_id_not_unique',
+      code: 'provided_patient_id_not_unique'
+    }]);
     test.done();
   });
 };

--- a/test/unit/transitions/utils.js
+++ b/test/unit/transitions/utils.js
@@ -26,7 +26,8 @@ exports['addRejectionMessage handles no configured messages'] = test => {
   test.equals(addMessage.args[0][0].phone, phone);
   test.equals(addError.callCount, 1);
   test.equals(addError.args[0][0]._id, 'a');
-  test.equals(addError.args[0][1], 'messages.generic.notfound');
+  test.equals(addError.args[0][1].message, 'messages.generic.notfound');
+  test.equals(addError.args[0][1].code, errorKey);
   test.done();
 };
 
@@ -58,6 +59,7 @@ exports['addRejectionMessage finds configured message'] = test => {
   test.equals(getMessage.args[0][1], 'xyz');
   test.equals(addError.callCount, 1);
   test.equals(addError.args[0][0]._id, 'a');
-  test.equals(addError.args[0][1], 'some message');
+  test.equals(addError.args[0][1].message, 'some message');
+  test.equals(addError.args[0][1].code, errorKey);
   test.done();
 };

--- a/transitions/utils.js
+++ b/transitions/utils.js
@@ -36,7 +36,10 @@ module.exports = {
     });
     // An "error" ends up being a doc.error, which is something that is shown
     // on the screen when you view the error. We need both
-    messages.addError(doc, message);
+    messages.addError(doc, {
+      message: message,
+      code: errorKey
+    });
   },
   addRegistrationNotFoundError: (doc, reportConfig) => {
     module.exports.addRejectionMessage(doc, reportConfig, 'registration_not_found');


### PR DESCRIPTION
# Description

When adding errors to a doc we record the message to display, but
it's helpful also to have an error code which can be inspected
programmatically without being affected by localisation and
configuration changes.

In particular this change allows us to detect when no patient is
found with the given identifier.

medic/medic-webapp#3437

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
