### PR TITLE
Gracefully handle missing key

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -277,6 +277,33 @@ const getVal = (obj, path) => {
   return obj;
 };
 
+const getPatient = (db, patientShortcodeId, includeDocs, callback) => {
+  if (!patientShortcodeId) {
+    return callback();
+  }
+  const viewOpts = {
+    key: patientShortcodeId,
+    include_docs: includeDocs
+  };
+  db.medic.view('medic', 'patient_by_patient_shortcode_id', viewOpts, (err, results) => {
+    if (err) {
+      return callback(err);
+    }
+
+    if (!results.rows.length) {
+      return callback();
+    }
+
+    if (results.rows.length > 1) {
+      console.warn('More than one patient person document for shortcode ' + patientShortcodeId);
+    }
+
+    const patient = results.rows[0];
+    const result = includeDocs ? patient.doc : patient.id;
+    return callback(null, result);
+  });
+};
+
 module.exports = {
   getVal: getVal,
   getLocale: getLocale,
@@ -398,22 +425,17 @@ module.exports = {
   *     is not a valid way of determining if the patient with that id exists
   */
   getRegistrations: (options, callback) => {
-    const db = options.db,
-      id = options.id,
-      ids = options.ids;
-
     const viewOptions = {
       include_docs: true
     };
-
-    if (id) {
-      viewOptions.key = id;
+    if (options.id) {
+      viewOptions.key = options.id;
+    } else if (options.ids) {
+      viewOptions.keys = options.ids;
+    } else {
+      return callback(null, []);
     }
-    if (ids) {
-      viewOptions.keys = ids;
-    }
-
-    db.medic.view('medic', 'registered_patients', viewOptions, (err, data) => {
+    options.db.medic.view('medic', 'registered_patients', viewOptions, (err, data) => {
       if (err) {
         return callback(err);
       }
@@ -487,51 +509,14 @@ module.exports = {
    * of the patient's person contact to the caller
    */
   getPatientContactUuid: (db, patientShortcodeId, callback) => {
-    db.medic.view('medic', 'patient_by_patient_shortcode_id',
-      {
-        key: patientShortcodeId
-      },
-      (err, results) => {
-        if (err) {
-          return callback(err);
-        }
-
-        if (!results.rows.length) {
-          return callback();
-        }
-
-        if (results.rows.length > 1) {
-          console.warn('More than one patient person document for shortcode ' + patientShortcodeId);
-        }
-
-        return callback(null, results.rows[0].id);
-    });
+    getPatient(db, patientShortcodeId, false, callback);
   },
   /*
    * Given a patient "shortcode" (as used in SMS reports), return the
    * patient's person record
    */
   getPatientContact: (db, patientShortcodeId, callback) => {
-    db.medic.view('medic', 'patient_by_patient_shortcode_id',
-      {
-        key: patientShortcodeId,
-        include_docs: true
-      },
-      (err, results) => {
-        if (err) {
-          return callback(err);
-        }
-
-        if (!results.rows.length) {
-          return callback();
-        }
-
-        if (results.rows.length > 1) {
-          console.warn('More than one patient person document for shortcode ' + patientShortcodeId);
-        }
-
-        return callback(null, results.rows[0].doc);
-    });
+    getPatient(db, patientShortcodeId, true, callback);
   },
   /*
    * Used to avoid infinite loops of auto-reply messages between gateway and

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -473,3 +473,123 @@ exports['addMessage truncates long unicode sms'] = function(test) {
     test.equals(message.original_message, sms);
     test.done();
 };
+
+exports['getPatientContactUuid returns the ID for the given short code'] = test => {
+    const expected = 'abc123';
+    const given = '55998';
+    const patients = [ { id: expected } ];
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: patients });
+    utils.getPatientContactUuid(db, given, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual, expected);
+        test.equals(view.callCount, 1);
+        test.equals(view.args[0][0], 'medic');
+        test.equals(view.args[0][1], 'patient_by_patient_shortcode_id');
+        test.equals(view.args[0][2].key, given);
+        test.equals(view.args[0][2].include_docs, false);
+        test.done();
+    });
+};
+
+exports['getPatientContactUuid returns empty when no patient found'] = test => {
+    const given = '55998';
+    const patients = [ ];
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: patients });
+    utils.getPatientContactUuid(db, given, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual, null);
+        test.equals(view.callCount, 1);
+        test.done();
+    });
+};
+
+exports['getPatientContactUuid returns empty when no shortcode given'] = test => {
+    const view = sinon.stub(db.medic, 'view');
+    utils.getPatientContactUuid(db, null, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual, null);
+        test.equals(view.callCount, 0);
+        test.done();
+    });
+};
+
+exports['getPatientContact returns the patient for the given short code'] = test => {
+    const expected = 'abc123';
+    const given = '55998';
+    const patients = [ { id: expected, doc: { _id: expected, name: 'jim', patient_id: given } } ];
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: patients });
+    utils.getPatientContact(db, given, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual.name, 'jim');
+        test.equals(view.callCount, 1);
+        test.equals(view.args[0][0], 'medic');
+        test.equals(view.args[0][1], 'patient_by_patient_shortcode_id');
+        test.equals(view.args[0][2].key, given);
+        test.equals(view.args[0][2].include_docs, true);
+        test.done();
+    });
+};
+
+exports['getPatientContact returns empty when no patient found'] = test => {
+    const given = '55998';
+    const patients = [ ];
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: patients });
+    utils.getPatientContact(db, given, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual, null);
+        test.equals(view.callCount, 1);
+        test.done();
+    });
+};
+
+exports['getPatientContact returns empty when no shortcode given'] = test => {
+    const view = sinon.stub(db.medic, 'view');
+    utils.getPatientContact(db, null, (err, actual) => {
+        test.equals(err, null);
+        test.equals(actual, null);
+        test.equals(view.callCount, 0);
+        test.done();
+    });
+};
+
+exports['getRegistrations queries by id if given'] = test => {
+    const expected = [ { id: 'a' } ];
+    const given = '22222';
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: expected });
+    utils.getRegistrations({ db: db, id: given }, (err, actual) => {
+        test.equals(err, null);
+        test.deepEqual(actual, expected);
+        test.equals(view.callCount, 1);
+        test.equals(view.args[0][0], 'medic');
+        test.equals(view.args[0][1], 'registered_patients');
+        test.equals(view.args[0][2].key, given);
+        test.equals(view.args[0][2].include_docs, true);
+        test.done();
+    });
+};
+
+exports['getRegistrations queries by ids if given'] = test => {
+    const expected = [ { id: 'a' }, { id: 'b' } ];
+    const given = ['11111', '22222'];
+    const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: expected });
+    utils.getRegistrations({ db: db, ids: given }, (err, actual) => {
+        test.equals(err, null);
+        test.deepEqual(actual, expected);
+        test.equals(view.callCount, 1);
+        test.equals(view.args[0][0], 'medic');
+        test.equals(view.args[0][1], 'registered_patients');
+        test.equals(view.args[0][2].keys, given);
+        test.equals(view.args[0][2].include_docs, true);
+        test.done();
+    });
+};
+
+exports['getRegistrations returns empty array if id or ids'] = test => {
+    const view = sinon.stub(db.medic, 'view');
+    utils.getRegistrations({ db: db }, (err, actual) => {
+        test.equals(err, null);
+        test.deepEqual(actual, []);
+        test.equals(view.callCount, 0);
+        test.done();
+    });
+};


### PR DESCRIPTION
# Description

This resolves an issue where a report without a patient_id fetched
and proceeded to clear the messages of all registrations in the
database. While this was a bug with the configuration, this change
makes it harder for a configuration mistake to corrupt the data.

medic/medic-webapp#3742

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
