### PR TITLE
Allow for deleted lineage entries

### DIFF
--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -3,7 +3,8 @@ const db = require('../db');
 const bindContacts = (lineage, contacts) => {
   contacts.forEach(contactDoc => {
     const stub = lineage.find(lineageDoc => {
-      const id = lineageDoc.contact &&
+      const id = lineageDoc &&
+                 lineageDoc.contact &&
                  lineageDoc.contact._id;
       return id === contactDoc._id;
     });

--- a/test/unit/lineage.js
+++ b/test/unit/lineage.js
@@ -53,9 +53,14 @@ exports['fetchHydratedDoc handles no lineage and no contact'] = test => {
 exports['fetchHydratedDoc handles doc with deleted parent'] = test => {
   const docId = 'abc';
   sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'abc' } }, { doc: null } ] });
-  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [] });
-  lineage.fetchHydratedDoc(docId).then(actual => {
+  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [ { doc: { _id: 'cba' } } ] });
+  lineage.fetchHydratedDoc(docId)
+  .then(actual => {
     test.deepEqual(actual, { _id: 'abc', parent: null });
+    test.done();
+  })
+  .catch(err => {
+    test.fail(err);
     test.done();
   });
 };


### PR DESCRIPTION
# Description

If you (I think) have a lineage entry for a deleted document you get a null document in your lineage list.

medic/medic-webapp#3757

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
