### PR TITLE
Scheduled messages support person in message template

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -3,6 +3,34 @@ var _ = require('underscore'),
     utils = require('./utils'),
     logger = require('./logger');
 
+function extendedTemplateContext(doc, extras) {
+    const templateContext = module.exports.extractTemplateContext(doc);
+
+    if (extras.templateContext) {
+        _.defaults(templateContext, extras.templateContext);
+    }
+
+    if (extras.patient) {
+        _.defaults(templateContext, module.exports.extractTemplateContext(extras.patient));
+    }
+
+    if (extras.registrations && extras.registrations.length) {
+        _.defaults(templateContext, module.exports.extractTemplateContext(extras.registrations[0].doc));
+    }
+
+    if (extras.person) {
+        templateContext.person = extras.person;
+
+        // For backwards compatibilty. Configurers are used to the patient's
+        // name being available here, so alias it for now. This could be dropped
+        // in a future major release if we ever decide to revisit and
+        // standardise how we expose data to the message templater.
+        templateContext.patient_name = templateContext.patient_name || templateContext.person.name;
+    }
+
+    return templateContext;
+}
+
 /**
  * Expected opts :
  * - doc
@@ -11,6 +39,7 @@ var _ = require('underscore'),
  * - templateContext (optional)
  * - registrations (optional)
  * - person (optional)
+ * - patient (optional)
  * - state (optional)
  * - taskFields (optional)
  * All other fields are ignored.
@@ -18,7 +47,7 @@ var _ = require('underscore'),
 function addMessage(opts) {
     var self = module.exports,
         doc = opts.doc,
-        templateContext = module.exports.extractTemplateContext(doc),
+        templateContext = extendedTemplateContext(doc, opts),
         phone = opts.phone || self.getRecipientPhone(doc, 'clinic');
 
     if (!phone) {
@@ -29,28 +58,6 @@ function addMessage(opts) {
     if (!opts.message) {
         logger.debug(`Can't add message, no message template found in opts: ${opts}`);
         return;
-    }
-
-    if (opts.templateContext) {
-        _.defaults(templateContext, opts.templateContext);
-    }
-
-    if (opts.patient) {
-        _.defaults(templateContext, module.exports.extractTemplateContext(opts.patient));
-    }
-
-    if (opts.registrations && opts.registrations.length) {
-        _.defaults(templateContext, module.exports.extractTemplateContext(opts.registrations[0].doc));
-    }
-
-    if (opts.person) {
-        templateContext.person = opts.person;
-
-        // For backwards compatibilty. Configurers are used to the patient's
-        // name being available here, so alias it for now. This could be dropped
-        // in a future major release if we ever decide to revisit and
-        // standardise how we expose data to the message templater.
-        templateContext.patient_name = templateContext.patient_name || templateContext.person.name;
     }
 
     let outputOpts = {
@@ -122,11 +129,12 @@ module.exports = {
         };
         return _.defaults(internal, doc.fields, doc);
     },
-    scheduleMessage: function(doc, msg, phone, registrations) {
-        var templateContext = module.exports.extractTemplateContext(doc);
-        if (registrations && registrations.length) {
-            _.defaults(templateContext, module.exports.extractTemplateContext(registrations[0].doc));
-        }
+    scheduleMessage: function(doc, msg, phone, registrations, person) {
+        var templateContext = extendedTemplateContext(doc, {
+            registrations: registrations,
+            person: person
+        });
+
         phone = phone ? String(phone) : phone;
 
         try {

--- a/lib/schedules.js
+++ b/lib/schedules.js
@@ -63,7 +63,7 @@ module.exports = {
     /*
      * Take doc and schedule config and setup schedule tasks.
      */
-    assignSchedule: function(doc, schedule, registrations) {
+    assignSchedule: function(doc, schedule, registrations, person) {
         var self = module.exports,
             docStart,
             start,
@@ -126,7 +126,7 @@ module.exports = {
                     group: msg.group,
                     type: schedule.name,
                     translation_key: schedule.translation_key
-                }, phone, registrations);
+                }, phone, registrations, person);
             } else {
                 // bad offset, skip this msg
                 console.error(

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -69,6 +69,42 @@ exports['scheduleMessage supports template variables on doc'] = function(test) {
     test.done();
 };
 
+exports['scheduleMessage lets you use info from a passed person'] = test => {
+    var doc = {
+        form: 'x',
+        reported_date: '2050-03-13T13:06:22.002Z',
+    };
+    var msg = {
+        message: 'Hello {{person.name}}.',
+        due: moment().toISOString()
+    };
+    messages.scheduleMessage(doc, msg, '+13125551212', [], {name: 'Sally'});
+    test.equals(doc.scheduled_tasks.length, 1);
+    test.equals(
+        doc.scheduled_tasks[0].messages[0].message,
+        'Hello Sally.'
+    );
+    test.done();
+};
+
+exports['scheduleMessage aliases person.name to patient_name for backwards compat'] = test => {
+    var doc = {
+        form: 'x',
+        reported_date: '2050-03-13T13:06:22.002Z',
+    };
+    var msg = {
+        message: 'Hello {{patient_name}}.',
+        due: moment().toISOString()
+    };
+    messages.scheduleMessage(doc, msg, '+13125551212', [], {name: 'Sally'});
+    test.equals(doc.scheduled_tasks.length, 1);
+    test.equals(
+        doc.scheduled_tasks[0].messages[0].message,
+        'Hello Sally.'
+    );
+    test.done();
+};
+
 exports['scheduleMessage adds registration details to message context'] = function(test) {
     var doc = {
         form: 'x',

--- a/test/unit/schedules.js
+++ b/test/unit/schedules.js
@@ -1,12 +1,5 @@
-var _ = require('underscore'),
-    moment = require('moment'),
+var moment = require('moment'),
     schedules = require('../../lib/schedules');
-
-exports['function signature'] = function(test) {
-    test.ok(_.isFunction(schedules.assignSchedule));
-    test.equals(schedules.assignSchedule.length, 3);
-    test.done();
-};
 
 exports['getOffset returns false for bad syntax'] = function(test) {
     test.equals(schedules.getOffset('x'), false);

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -368,8 +368,8 @@ module.exports = {
       if (err) {
         return callback(err);
       }
-      options.params.forEach(name => {
-        const schedule = schedules.getScheduleConfig(name);
+      options.params.forEach(scheduleName => {
+        const schedule = schedules.getScheduleConfig(scheduleName);
         const assigned = schedules.assignSchedule(
           options.doc, schedule, registrations, person);
         if (!assigned) {

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -359,23 +359,25 @@ module.exports = {
     });
   },
   assignSchedule: (options, callback) => {
-    getRegistrations(
-      options.db,
-      options.doc.fields && options.doc.fields.patient_id,
-      (err, registrations) => {
-        if (err) {
-          return callback(err);
-        }
-        options.params.forEach(name => {
-          const schedule = schedules.getScheduleConfig(name);
-          const assigned = schedules.assignSchedule(options.doc, schedule, registrations);
-          if (!assigned) {
-            logger.error('Failed to add schedule please verify settings.');
-          }
-        });
-        callback();
+    const patientId = options.doc.fields && options.doc.fields.patient_id;
+
+    async.parallel({
+      registrations: _.partial(getRegistrations, options.db, patientId),
+      person: _.partial(utils.getPatientContact, options.db, patientId)
+    }, (err, {registrations, person}) => {
+      if (err) {
+        return callback(err);
       }
-    );
+      options.params.forEach(name => {
+        const schedule = schedules.getScheduleConfig(name);
+        const assigned = schedules.assignSchedule(
+          options.doc, schedule, registrations, person);
+        if (!assigned) {
+          logger.error('Failed to add schedule please verify settings.');
+        }
+      });
+      callback();
+    });
   },
   setId: (options, callback) => {
     const doc = options.doc,


### PR DESCRIPTION
# Description

Extend support for the person document to scheduled messages as well as standard messages.
Support the same legacy hook for `{{patient_name}}`.

medic/medic-webapp#3419

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
