### PR TITLE
Use new_report in multi_form_alert recipient context.

### DIFF
--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -224,7 +224,7 @@ exports['if enough reports pass the is_report_counted func, adds message'] = tes
 };
 
 exports['adds message when recipient is evaled'] = test => {
-  const recipient = 'countedReport.contact.phone';
+  const recipient = 'new_report.contact.phone';
   alert.recipients = [recipient];
   alert.num_reports_threshold = 1;
   sinon.stub(config, 'get').returns([alert]);
@@ -244,7 +244,7 @@ exports['adds message when recipient is evaled'] = test => {
 };
 
 exports['adds multiple messages when multiple recipients are evaled'] = test => {
-  alert.recipients = [ 'countedReport.contact.phone' ];
+  alert.recipients = [ 'new_report.contact.phone' ];
   sinon.stub(config, 'get').returns([alert]);
 
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
@@ -266,7 +266,7 @@ exports['adds multiple messages when multiple recipients are evaled'] = test => 
 };
 
 exports['does not add message when recipient cannot be evaled'] = test => {
-  const recipient = 'countedReport.contact.phonekkk'; // field doesn't exist
+  const recipient = 'new_report.contact.phonekkk'; // field doesn't exist
   alert.recipients = [recipient];
   sinon.stub(config, 'get').returns([alert]);
 
@@ -386,7 +386,7 @@ exports['message only contains newReports'] = test => {
 };
 
 exports['adds multiple messages when mutiple recipients'] = test => {
-  alert.recipients = ['+254111222333', 'countedReport.contact.phone'];
+  alert.recipients = ['+254111222333', 'new_report.contact.phone'];
   sinon.stub(config, 'get').returns([alert]);
 
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
@@ -412,7 +412,7 @@ exports['adds multiple messages when mutiple recipients'] = test => {
 
 exports['dedups message recipients'] = test => {
   // specify same recipient twice.
-  alert.recipients = ['countedReport.contact.phone', 'countedReport.contact.phone'];
+  alert.recipients = ['new_report.contact.phone', 'new_report.contact.phone'];
   sinon.stub(config, 'get').returns([alert]);
 
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));

--- a/transitions/multi_report_alerts.js
+++ b/transitions/multi_report_alerts.js
@@ -85,8 +85,8 @@ const generateMessages = (alert, phones, latestReport, countedReportsIds, newRep
 // Recipients format examples:
 // [
 //    '+254777888999',
-//    'countedReport.contact.parent.parent.contact.phone',   // returns string
-//    'countedReport.contact.parent.parent.alertRecipients', // returns string array
+//    'new_report.contact.parent.parent.contact.phone',   // returns string
+//    'new_report.contact.parent.parent.alertRecipients', // returns string array
 // ]
 const getPhones = (recipients, reports) => {
   let phones = [];
@@ -114,7 +114,7 @@ const getPhonesOneReport = (recipients, report) => {
   return _.uniq(phones);
 };
 
-const getPhonesOneReportOneRecipientWithDuplicates = (recipient, countedReport) => {
+const getPhonesOneReportOneRecipientWithDuplicates = (recipient, newReport) => {
   if (!recipient) {
     return [];
   }
@@ -123,7 +123,7 @@ const getPhonesOneReportOneRecipientWithDuplicates = (recipient, countedReport) 
     return [recipient];
   }
 
-  const context = { countedReport: countedReport };
+  const context = { new_report: newReport };
   try {
     const evaled = vm.runInNewContext(recipient, context);
     if (_.isString(evaled)) {


### PR DESCRIPTION
# Description
Rename variable, including in the context used to evaluate the recipients. 
medic/medic-webapp#3715

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
