### PR TITLE
Fix lineage.hydrateDocs to use the right fields for data_records. 

### DIFF
--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -1,20 +1,25 @@
-const db = require('../db');
+const _ = require('underscore'),
+    db = require('../db');
 
-const bindContacts = (lineage, contacts) => {
+const fillContactsInDocs = (docs, contacts) => {
+  if (!contacts || !contacts.length) {
+    return docs;
+  }
   contacts.forEach(contactDoc => {
-    const stub = lineage.find(lineageDoc => {
-      const id = lineageDoc &&
-                 lineageDoc.contact &&
-                 lineageDoc.contact._id;
+    const stub = docs.find(doc => {
+      const id = doc &&
+                 doc.contact &&
+                 doc.contact._id;
       return id === contactDoc._id;
     });
     if (stub) {
       stub.contact = contactDoc;
     }
   });
+  return docs;
 };
 
-const bindParents = (lineage, doc) => {
+const buildHydratedDoc = (doc, lineage) => {
   if (!doc) {
     return doc;
   }
@@ -68,75 +73,133 @@ const fetchHydratedDoc = id => {
       const contactIds = lineage
         .map(doc => doc && doc.contact && doc.contact._id)
         .filter(id => !!id);
-      db.medic.fetch({ keys: contactIds }, (err, contactResults) => {
-        if (err) {
-          return reject(err);
-        }
-        const contacts = contactResults.rows
-          .map(row => row.doc)
-          .filter(doc => !!doc);
-        bindContacts(lineage, contacts);
-        const doc = lineage.shift();
-        bindParents(lineage, doc);
-        resolve(doc);
-      });
+
+      return resolve(fetchDocs(contactIds)
+        .then(contacts => {
+          fillContactsInDocs(lineage, contacts);
+          const doc = lineage.shift();
+          buildHydratedDoc(doc, lineage);
+          return doc;
+        }));
     });
   });
 };
 
-const findRow = (rows, id) => id && rows.find(row => row.id === id);
-
-const collectContactIds = docs => {
+// for data_records, include the first-level contact.
+const collectParentIds = docs => {
   const ids = [];
   docs.forEach(doc => {
-    const contactId = doc.contact && doc.contact._id;
-    if (contactId && !ids.includes(contactId)) {
-      ids.push(contactId);
-    }
     let parent = doc.parent;
+    if (doc.type === 'data_record') {
+      const contactId = doc.contact && doc.contact._id;
+      if (!contactId) {
+        return;
+      }
+      ids.push(contactId);
+      parent = doc.contact;
+    }
     while (parent) {
-      if (parent._id && !ids.includes(parent._id)) {
+      if (parent._id) {
         ids.push(parent._id);
       }
       parent = parent.parent;
     }
   });
-  return ids;
+  return _.uniq(ids);
+};
+
+// for data_records, doesn't include the first-level contact (it counts as a parent).
+const collectLeafContactIds = partiallyHydratedDocs => {
+  const ids = [];
+  partiallyHydratedDocs.forEach(doc => {
+    let current = doc;
+    if (current.type === 'data_record') {
+      current = current.contact;
+    }
+    while (current) {
+      const contactId = current.contact && current.contact._id;
+      if (contactId) {
+        ids.push(contactId);
+      }
+      current = current.parent;
+    }
+  });
+  return _.uniq(ids);
+};
+
+const fetchDocs = ids => {
+  return new Promise((resolve, reject) => {
+    if (!ids || !ids.length) {
+      return resolve([]);
+    }
+    db.medic.fetch({ keys: ids }, (err, results) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(results.rows.map(row => row.doc).filter(doc => !!doc));
+    });
+  });
+};
+
+const hydrateParents = (docs, parents) => {
+  if (!parents || !parents.length) {
+    return docs;
+  }
+  docs.forEach(doc => {
+    let current = doc;
+    if (doc.type === 'data_record') {
+      const contactDoc = parents.find(parent => parent._id === current.contact._id);
+      if (contactDoc) {
+        doc.contact = contactDoc;
+      }
+      current = doc.contact;
+    }
+
+    while (current) {
+      if (current.parent && current.parent._id) {
+        /*jshint loopfunc:true */
+        const parentDoc = parents.find(parent => parent._id === current.parent._id);
+        if (parentDoc) {
+          current.parent = parentDoc;
+        }
+      }
+      current = current.parent;
+    }
+  });
+  return docs;
+};
+
+const hydrateLeafContacts = (docs, contacts) => {
+  const subDocsToHydrate = [];
+  docs.forEach(doc => {
+    let current = doc;
+    if (doc.type === 'data_record') {
+      current = doc.contact;
+    }
+    while (current) {
+      subDocsToHydrate.push(current);
+      current = current.parent;
+    }
+  });
+  fillContactsInDocs(subDocsToHydrate, contacts);
+  return docs;
 };
 
 const hydrateDocs = docs => {
   if (!docs.length) {
     return Promise.resolve([]);
   }
-  const ids = collectContactIds(docs);
-  if (!ids.length) {
-    return Promise.resolve(docs);
-  }
-  return new Promise((resolve, reject) => {
-    db.medic.fetch({ keys: ids }, (err, results) => {
-      if (err) {
-        return reject(err);
-      }
-      const rows = results.rows;
-
-      const hydratedDocs = JSON.parse(JSON.stringify(docs));
-      hydratedDocs.forEach(doc => {
-        const row = findRow(rows, doc.contact && doc.contact._id);
-        if (row && row.doc) {
-          doc.contact = row.doc;
-        }
-        let parent = doc;
-        while (parent) {
-          const row = findRow(rows, parent.parent && parent.parent._id);
-          if (row && row.doc) {
-            parent.parent = row.doc;
-          }
-          parent = parent.parent;
-        }
-      });
-      resolve(hydratedDocs);
+  const parentIds = collectParentIds(docs);
+  const hydratedDocs = JSON.parse(JSON.stringify(docs));
+  return fetchDocs(parentIds)
+    .then(parents => {
+      hydrateParents(hydratedDocs, parents);
+      return fetchDocs(collectLeafContactIds(hydratedDocs));
+    })
+    .then(contacts => {
+      hydrateLeafContacts(hydratedDocs, contacts);
+      return hydratedDocs;
     });
-  });
 };
 
 module.exports = {

--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -145,10 +145,13 @@ const hydrateParents = (docs, parents) => {
   if (!parents || !parents.length) {
     return docs;
   }
+
+  const findById = (id, docs) => docs.find(doc => doc._id === id);
+
   docs.forEach(doc => {
     let current = doc;
     if (doc.type === 'data_record') {
-      const contactDoc = parents.find(parent => parent._id === current.contact._id);
+      const contactDoc = findById(current.contact._id, parents);
       if (contactDoc) {
         doc.contact = contactDoc;
       }
@@ -157,8 +160,7 @@ const hydrateParents = (docs, parents) => {
 
     while (current) {
       if (current.parent && current.parent._id) {
-        /*jshint loopfunc:true */
-        const parentDoc = parents.find(parent => parent._id === current.parent._id);
+        const parentDoc = findById(current.parent._id, parents);
         if (parentDoc) {
           current.parent = parentDoc;
         }

--- a/test/unit/lineage.js
+++ b/test/unit/lineage.js
@@ -2,510 +2,514 @@ const db = require('../../db'),
       sinon = require('sinon').sandbox.create(),
       lineage = require('../../lib/lineage');
 
-exports.tearDown = function(callback) {
+exports.tearDown = callback => {
   sinon.restore();
   callback();
 };
 
+let report_parentContact,
+  report_grandparentContact,
+  report_grandparent,
+  report_parent,
+  report_contact,
+  report,
+  place_parentContact,
+  place_grandparentContact,
+  place_contact,
+  place_parent,
+  place_grandparent,
+  place;
+exports.setUp = callback => {
+  report_parentContact = {
+    _id: 'report_parentContact',
+    name: 'report_parentContact_name',
+    type: 'person',
+    phone: '+123'
+  };
+  report_grandparentContact = {
+    _id: 'report_grandparentContact',
+    name: 'report_grandparentContact_name',
+    type: 'person',
+    phone: '+456'
+  };
+  report_grandparent = {
+    _id: 'report_grandparent',
+    contact: { _id: report_grandparentContact._id },
+    name: 'report_grandparent_name'
+  };
+  report_parent = {
+    _id: 'report_parent',
+    name: 'report_parent_name',
+    contact: { _id: report_parentContact._id },
+    parent: {
+      _id: report_grandparent._id
+    }
+  };
+  report_contact = {
+    _id: 'report_contact',
+    type: 'person',
+    name: 'report_contact_name',
+    parent: {
+      _id: report_parent._id,
+      parent: {
+        _id: report_grandparent._id
+      }
+    }
+  };
+  report = {
+    _id: 'report',
+    type: 'data_record',
+    form: 'A',
+    contact: {
+      _id: report_contact._id,
+      parent: {
+        _id: report_parent._id,
+        parent: {
+          _id: report_grandparent._id
+        }
+      }
+    }
+  };
+
+  place_parentContact = {
+    _id: 'place_parentContact',
+    name: 'place_parentContact_name',
+    type: 'person',
+    phone: '+123'
+  };
+  place_grandparentContact = {
+    _id: 'place_grandparentContact',
+    name: 'place_grandparentContact_name',
+    phone: '+456'
+  };
+  place_contact = {
+    _id: 'place_contact',
+    type: 'place_contact_name',
+    phone: '+789'
+  };
+  place_grandparent = {
+    _id: 'place_grandparent',
+    name: 'place_grandparent_name',
+    contact: { _id: place_grandparentContact._id }
+  };
+  place_parent = {
+    _id: 'place_parent',
+    name: 'place_parent_name',
+    contact: { _id: place_parentContact._id },
+    parent: {
+      _id: place_grandparent._id
+    }
+  };
+  place = {
+    _id: 'place',
+    name: 'place_name',
+    contact: { _id: place_contact._id },
+    parent: {
+      _id: place_parent._id,
+      parent: {
+        _id: place_grandparent._id
+      }
+    }
+  };
+  callback();
+};
+
+
 exports['fetchHydratedDoc returns errors from view'] = test => {
-  const expected = 'boom';
-  const id = 'abc';
-  const view = sinon.stub(db.medic, 'view').callsArgWith(3, expected);
-  lineage.fetchHydratedDoc(id).catch(err => {
-    test.equals(err, expected);
-    test.equals(view.callCount, 1);
-    test.equals(view.args[0][0], 'medic-client');
-    test.equals(view.args[0][1], 'docs_by_id_lineage');
-    test.deepEqual(view.args[0][2].startkey, [ id ]);
-    test.deepEqual(view.args[0][2].endkey, [ id, {} ]);
-    test.deepEqual(view.args[0][2].include_docs, true);
-    test.done();
-  });
+const expected = 'boom';
+const id = 'abc';
+const view = sinon.stub(db.medic, 'view').callsArgWith(3, expected);
+lineage.fetchHydratedDoc(id).catch(err => {
+  test.equals(err, expected);
+  test.equals(view.callCount, 1);
+  test.equals(view.args[0][0], 'medic-client');
+  test.equals(view.args[0][1], 'docs_by_id_lineage');
+  test.deepEqual(view.args[0][2].startkey, [ id ]);
+  test.deepEqual(view.args[0][2].endkey, [ id, {} ]);
+  test.deepEqual(view.args[0][2].include_docs, true);
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc returns errors from fetch'] = test => {
-  const expected = 'boom';
-  const docId = 'abc';
-  const contactId = 'def';
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, {
-    rows: [ { doc: { contact: { _id: contactId } } } ]
-  });
-  const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, expected);
-  lineage.fetchHydratedDoc(docId).catch(err => {
-    test.equals(err, expected);
-    test.equals(fetch.callCount, 1);
-    test.done();
-  });
+const expected = 'boom';
+const docId = 'abc';
+const contactId = 'def';
+sinon.stub(db.medic, 'view').callsArgWith(3, null, {
+  rows: [ { doc: { contact: { _id: contactId } } } ]
+});
+const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, expected);
+lineage.fetchHydratedDoc(docId).catch(err => {
+  test.equals(err, expected);
+  test.equals(fetch.callCount, 1);
+  test.done();
+}).catch(test.done);
 };
 
 exports['fetchHydratedDoc handles no lineage and no contact'] = test => {
-  const docId = 'abc';
-  const expected = { _id: docId };
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: expected } ] });
-  const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [] });
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    test.deepEqual(actual, expected);
-    test.equals(fetch.callCount, 1);
-    test.done();
-  });
+const docId = 'abc';
+const expected = { _id: docId };
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: expected } ] });
+sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [] });
+lineage.fetchHydratedDoc(docId).then(actual => {
+  test.deepEqual(actual, expected);
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc handles doc with deleted parent'] = test => {
-  const docId = 'abc';
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'abc' } }, { doc: null } ] });
-  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [ { doc: { _id: 'cba' } } ] });
-  lineage.fetchHydratedDoc(docId)
-  .then(actual => {
-    test.deepEqual(actual, { _id: 'abc', parent: null });
-    test.done();
-  })
-  .catch(err => {
-    test.fail(err);
-    test.done();
-  });
+const docId = 'abc';
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'abc' } }, { doc: null } ] });
+sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [ { doc: { _id: 'cba' } } ] });
+lineage.fetchHydratedDoc(docId)
+.then(actual => {
+  test.deepEqual(actual, { _id: 'abc', parent: null });
+  test.done();
+})
+.catch(err => {
+  test.fail(err);
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc handles missing contacts'] = test => {
-  const docId = 'abc';
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'abc', contact: { _id: 'xyz' } } } ] });
-  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [ { doc: null }] });
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    test.deepEqual(actual, { _id: 'abc', contact: { _id: 'xyz' }, parent: undefined });
-    test.done();
-  });
+const docId = 'abc';
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'abc', contact: { _id: 'xyz' } } } ] });
+sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [ { doc: null }] });
+lineage.fetchHydratedDoc(docId).then(actual => {
+  test.deepEqual(actual, { _id: 'abc', contact: { _id: 'xyz' }, parent: undefined });
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc attaches the lineage'] = test => {
-  const docId = 'abc';
-  const parent = {
-    _id: 'def',
-    name: 'jack',
+const docId = 'abc';
+const parent = {
+  _id: 'def',
+  name: 'jack',
+  parent: {
+    _id: 'ghi'
+  }
+};
+const grandparent = {
+  _id: 'ghi',
+  name: 'jim'
+};
+const given = {
+  _id: docId,
+  name: 'joe',
+  parent: {
+    _id: parent._id,
     parent: {
-      _id: 'ghi'
+      _id: grandparent._id
     }
-  };
-  const grandparent = {
-    _id: 'ghi',
-    name: 'jim'
-  };
-  const given = {
-    _id: docId,
-    name: 'joe',
-    parent: {
-      _id: parent._id,
-      parent: {
-        _id: grandparent._id
-      }
-    }
-  };
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { doc: given },
-    { doc: parent },
-    { doc: grandparent }
-  ] });
-  const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [] }); // without subcontacts
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    test.equals(actual.name, 'joe');
-    test.equals(actual.parent.name, 'jack');
-    test.equals(actual.parent.parent.name, 'jim');
-    test.equals(fetch.callCount, 1);
-    test.done();
-  });
+  }
+};
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  { doc: given },
+  { doc: parent },
+  { doc: grandparent }
+] });
+sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [] }); // without subcontacts
+lineage.fetchHydratedDoc(docId).then(actual => {
+  test.equals(actual.name, 'joe');
+  test.equals(actual.parent.name, 'jack');
+  test.equals(actual.parent.parent.name, 'jim');
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc attaches the full lineage for reports'] = test => {
-  const docId = 'abc';
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  { doc: report },
+  { doc: report_contact },
+  { doc: report_parent },
+  { doc: report_grandparent }
+] });
 
-  const parentContact = {
-    _id: 'contact-def',
-    phone: '+123'
-  };
-  const grandparentContact = {
-    _id: 'contact-ghi',
-    phone: '+456'
-  };
-  const parent = {
-    _id: 'def',
-    name: 'jack',
-    contact: { _id: parentContact._id },
-    parent: {
-      _id: 'ghi'
-    }
-  };
-  const grandparent = {
-    _id: 'ghi',
-    contact: { _id: grandparentContact._id },
-    name: 'jim'
-  };
-  const givenContact = {
-    _id: 'contact',
-    name: 'apex',
-    parent: {
-      _id: parent._id,
-      parent: {
-        _id: grandparent._id
-      }
-    }
-  };
-  const given = {
-    _id: docId,
-    type: 'data_record',
-    form: 'A',
-    contact: {
-      _id: givenContact._id,
-      parent: {
-        _id: parent._id,
-        parent: {
-          _id: grandparent._id
-        }
-      }
-    }
-  };
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { doc: given },
-    { doc: givenContact },
-    { doc: parent },
-    { doc: grandparent }
-  ] });
-
-  const fetch = sinon.stub(db.medic, 'fetch');
-  fetch.callsFake((options, callback) => {
-    const contactDocs = options.keys.map(id => {
-      return [ givenContact, parentContact, grandparentContact ]
-        .find(contact => contact._id === id);
-    });
-    callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.callsFake((options, callback) => {
+  const contactDocs = options.keys.map(id => {
+    return [ report_contact, report_parentContact, report_grandparentContact ]
+      .find(contact => contact._id === id);
   });
+  callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
+});
 
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    test.equals(actual.form, 'A');
-    // parents
-    test.equals(actual.contact.name, 'apex');
-    test.equals(actual.contact.parent.name, 'jack');
-    test.equals(actual.contact.parent.parent.name, 'jim');
-    test.ok(!actual.parent);
-    // contacts of parents
-    test.equals(actual.contact.parent.contact.phone, '+123');
-    test.equals(actual.contact.parent.parent.contact.phone, '+456');
+lineage.fetchHydratedDoc(report._id).then(actual => {
+  test.equals(actual.form, 'A');
+  // parents
+  test.equals(actual.contact.name, report_contact.name);
+  test.equals(actual.contact.parent.name, report_parent.name);
+  test.equals(actual.contact.parent.parent.name, report_grandparent.name);
+  test.ok(!actual.parent);
+  // contacts of parents
+  test.equals(actual.contact.parent.contact.phone, '+123');
+  test.equals(actual.contact.parent.parent.contact.phone, '+456');
 
-    test.equals(fetch.callCount, 1);
-    test.done();
-  });
+  test.equals(fetch.callCount, 1);
+  test.done();
+});
 };
 
 exports['fetchHydratedDoc attaches the contacts'] = test => {
-  const docId = 'abc';
-  const parentContact = {
-    _id: 'contact-def',
-    phone: '+123'
-  };
-  const grandparentContact = {
-    _id: 'contact-ghi',
-    phone: '+456'
-  };
-  const givenContact = {
-    _id: 'contact-abc',
-    phone: '+789'
-  };
-  const parent = {
-    _id: 'def',
-    name: 'jack',
-    contact: { _id: parentContact._id },
-    parent: {
-      _id: 'ghi'
-    }
-  };
-  const grandparent = {
-    _id: 'ghi',
-    name: 'jim',
-    contact: { _id: grandparentContact._id }
-  };
-  const given = {
-    _id: docId,
-    name: 'joe',
-    contact: { _id: givenContact._id },
-    parent: {
-      _id: parent._id,
-      parent: {
-        _id: grandparent._id
-      }
-    }
-  };
-  const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { doc: given },
-    { doc: parent },
-    { doc: grandparent }
-  ] });
-  const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [
-    { doc: givenContact },
-    { doc: parentContact },
-    { doc: grandparentContact }
-  ] });
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    test.equals(actual.name, 'joe');
-    test.equals(actual.contact.phone, '+789');
-    test.equals(actual.parent.name, 'jack');
-    test.equals(actual.parent.contact.phone, '+123');
-    test.equals(actual.parent.parent.name, 'jim');
-    test.equals(actual.parent.parent.contact.phone, '+456');
-    test.equals(view.callCount, 1);
-    test.equals(view.args[0][0], 'medic-client');
-    test.equals(view.args[0][1], 'docs_by_id_lineage');
-    test.deepEqual(view.args[0][2].startkey, [ docId ]);
-    test.deepEqual(view.args[0][2].endkey, [ docId, {} ]);
-    test.equals(view.args[0][2].include_docs, true);
-    test.equals(fetch.callCount, 1);
-    test.deepEqual(fetch.args[0][0].keys, [ givenContact._id, parentContact._id, grandparentContact._id ]);
-    test.done();
-  });
+const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  { doc: place },
+  { doc: place_parent },
+  { doc: place_grandparent }
+] });
+const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [
+  { doc: place_contact },
+  { doc: place_parentContact },
+  { doc: place_grandparentContact }
+] });
+lineage.fetchHydratedDoc(place._id).then(actual => {
+  test.equals(actual.name, place.name);
+  test.equals(actual.contact.phone, '+789');
+  test.equals(actual.parent.name, place_parent.name);
+  test.equals(actual.parent.contact.phone, '+123');
+  test.equals(actual.parent.parent.name, place_grandparent.name);
+  test.equals(actual.parent.parent.contact.phone, '+456');
+  test.equals(view.callCount, 1);
+  test.equals(view.args[0][0], 'medic-client');
+  test.equals(view.args[0][1], 'docs_by_id_lineage');
+  test.deepEqual(view.args[0][2].startkey, [ place._id ]);
+  test.deepEqual(view.args[0][2].endkey, [ place._id, {} ]);
+  test.equals(view.args[0][2].include_docs, true);
+  test.equals(fetch.callCount, 1);
+  test.deepEqual(fetch.args[0][0].keys, [ place_contact._id, place_parentContact._id, place_grandparentContact._id ]);
+  test.done();
+});
 };
 
 exports['minify handles null argument'] = test => {
-  lineage.minify(null);
-  // just make sure it doesn't blow up!
-  test.done();
+lineage.minify(null);
+// just make sure it doesn't blow up!
+test.done();
 };
 
 exports['minify minifies the parent'] = test => {
-  const actual = {
-    _id: 'c',
-    name: 'cathy',
+const actual = {
+  _id: 'c',
+  name: 'cathy',
+  parent: {
+    _id: 'a',
+    name: 'arnold',
     parent: {
-      _id: 'a',
-      name: 'arnold',
-      parent: {
-        _id: 'b',
-        name: 'barry'
-      }
+      _id: 'b',
+      name: 'barry'
     }
-  };
-  const expected = {
-    _id: 'c',
-    name: 'cathy',
+  }
+};
+const expected = {
+  _id: 'c',
+  name: 'cathy',
+  parent: {
+    _id: 'a',
     parent: {
-      _id: 'a',
-      parent: {
-        _id: 'b'
-      }
+      _id: 'b'
     }
-  };
-  lineage.minify(actual);
-  test.deepEqual(actual, expected);
-  test.done();
+  }
+};
+lineage.minify(actual);
+test.deepEqual(actual, expected);
+test.done();
 };
 
 exports['minify minifies the contact and lineage'] = test => {
-  const actual = {
-    _id: 'c',
-    name: 'cathy',
+const actual = {
+  _id: 'c',
+  name: 'cathy',
+  parent: {
+    _id: 'a',
+    name: 'arnold',
     parent: {
-      _id: 'a',
-      name: 'arnold',
-      parent: {
-        _id: 'b',
-        name: 'barry'
-      }
-    },
-    contact: {
-      _id: 'd',
-      name: 'daniel',
-      parent: {
-        _id: 'e',
-        name: 'elisa'
-      }
+      _id: 'b',
+      name: 'barry'
     }
-  };
-  const expected = {
-    _id: 'c',
-    name: 'cathy',
+  },
+  contact: {
+    _id: 'd',
+    name: 'daniel',
     parent: {
-      _id: 'a',
-      parent: {
-        _id: 'b'
-      }
-    },
-    contact: {
-      _id: 'd',
-      parent: {
-        _id: 'e'
-      }
+      _id: 'e',
+      name: 'elisa'
     }
-  };
+  }
+};
+const expected = {
+  _id: 'c',
+  name: 'cathy',
+  parent: {
+    _id: 'a',
+    parent: {
+      _id: 'b'
+    }
+  },
+  contact: {
+    _id: 'd',
+    parent: {
+      _id: 'e'
+    }
+  }
+};
+lineage.minify(actual);
+test.deepEqual(actual, expected);
+test.done();
+};
+
+exports['fetchHydratedDoc+minify is noop on a report'] = test => {
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  { doc: JSON.parse(JSON.stringify(report)) },
+  { doc: report_contact },
+  { doc: report_parent },
+  { doc: report_grandparent }
+] });
+
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.callsFake((options, callback) => {
+  const contactDocs = options.keys.map(id => {
+    return [ report_contact, report_parentContact, report_grandparentContact ]
+      .find(contact => contact._id === id);
+  });
+  callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
+});
+
+lineage.fetchHydratedDoc(report._id).then(actual => {
   lineage.minify(actual);
-  test.deepEqual(actual, expected);
+  test.deepEqual(actual, report);
   test.done();
+});
 };
 
-exports['hydrate+minify is noop on a report'] = test => {
-  const docId = 'abc';
+exports['fetchHydratedDoc+minify is noop on a place'] = test => {
+sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  { doc: JSON.parse(JSON.stringify(place)) },
+  { doc: place_parent },
+  { doc: place_grandparent }
+] });
 
-  const parentContact = {
-    _id: 'contact-def',
-    phone: '+123'
-  };
-  const grandparentContact = {
-    _id: 'contact-ghi',
-    phone: '+456'
-  };
-  const parent = {
-    _id: 'def',
-    name: 'jack',
-    contact: { _id: parentContact._id },
-    parent: {
-      _id: 'ghi'
-    }
-  };
-  const grandparent = {
-    _id: 'ghi',
-    contact: { _id: grandparentContact._id },
-    name: 'jim'
-  };
-  const givenContact = {
-    _id: 'contact',
-    name: 'apex',
-    parent: {
-      _id: parent._id,
-      parent: {
-        _id: grandparent._id
-      }
-    }
-  };
-  const given = {
-    _id: docId,
-    type: 'data_record',
-    form: 'A',
-    contact: {
-      _id: givenContact._id,
-      parent: {
-        _id: parent._id,
-        parent: {
-          _id: grandparent._id
-        }
-      }
-    }
-  };
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { doc: JSON.parse(JSON.stringify(given)) },
-    { doc: givenContact },
-    { doc: parent },
-    { doc: grandparent }
-  ] });
-
-  const fetch = sinon.stub(db.medic, 'fetch');
-  fetch.callsFake((options, callback) => {
-    const contactDocs = options.keys.map(id => {
-      return [ givenContact, parentContact, grandparentContact ]
-        .find(contact => contact._id === id);
-    });
-    callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.callsFake((options, callback) => {
+  const contactDocs = options.keys.map(id => {
+    return [ place_contact, place_parentContact, place_grandparentContact ]
+      .find(contact => contact._id === id);
   });
+  callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
+});
 
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    lineage.minify(actual);
-    test.deepEqual(actual, given);
-    test.done();
-  });
-};
-
-exports['hydrate+minify is noop on a place'] = test => {
-  const docId = 'abc';
-  const parentContact = {
-    _id: 'contact-def',
-    phone: '+123'
-  };
-  const grandparentContact = {
-    _id: 'contact-ghi',
-    phone: '+456'
-  };
-  const givenContact = {
-    _id: 'contact-abc',
-    phone: '+789'
-  };
-  const parent = {
-    _id: 'def',
-    name: 'jack',
-    contact: { _id: parentContact._id },
-    parent: {
-      _id: 'ghi'
-    }
-  };
-  const grandparent = {
-    _id: 'ghi',
-    name: 'jim',
-    contact: { _id: grandparentContact._id }
-  };
-  const given = {
-    _id: docId,
-    name: 'joe',
-    contact: { _id: givenContact._id },
-    parent: {
-      _id: parent._id,
-      parent: {
-        _id: grandparent._id
-      }
-    }
-  };
-
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { doc: JSON.parse(JSON.stringify(given)) },
-    { doc: parent },
-    { doc: grandparent }
-  ] });
-
-  const fetch = sinon.stub(db.medic, 'fetch');
-  fetch.callsFake((options, callback) => {
-    const contactDocs = options.keys.map(id => {
-      return [ givenContact, parentContact, grandparentContact ]
-        .find(contact => contact._id === id);
-    });
-    callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
-  });
-
-  lineage.fetchHydratedDoc(docId).then(actual => {
-    lineage.minify(actual);
-    test.deepEqual(actual, given);
-    test.done();
-  });
+lineage.fetchHydratedDoc(place._id).then(actual => {
+  lineage.minify(actual);
+  test.deepEqual(actual, place);
+  test.done();
+});
 };
 
 exports['hydrateDocs binds contacts and parents'] = test => {
-  const docs = [
-    { _id: 'a', contact: { _id: 'b' }, parent: { _id: 'c', parent: { _id: 'e' }} },
-    { _id: 'a2', parent: { _id: 'd', parent: { _id: 'e' }} },
-  ];
-  const fetch = sinon.stub(db.medic, 'fetch').callsArgWith(1, null, { rows: [
-    { id: 'b', doc: { _id: 'b', name: 'barney' } },
-    { id: 'c', doc: null }, // cathy not found in databas
-    { id: 'd', doc: { _id: 'd', name: 'donny', parent: { _id: 'e' } } },
-    { id: 'e', doc: { _id: 'e', name: 'eric' } }
-  ] });
-  lineage.hydrateDocs(docs).then((hydratedDocs) => {
-    test.equals(hydratedDocs[0].contact.name, 'barney');
-    test.equals(hydratedDocs[0].parent.name, null);
-    test.equals(hydratedDocs[0].parent.parent.name, 'eric');
-    test.equals(hydratedDocs[1].parent.name, 'donny');
-    test.equals(hydratedDocs[1].parent.parent.name, 'eric');
-    test.equals(fetch.callCount, 1);
-    test.deepEqual(fetch.args[0][0].keys, [ 'b', 'c', 'e', 'd' ]);
-    test.done();
-  });
+const docs = [ report, place ];
+
+const fetchedParents = [ report_parent, report_grandparent, report_contact, place_parent, place_grandparent ];
+const fetchedContacts = [ report_parentContact, report_grandparentContact, place_contact, place_parentContact, place_grandparentContact ];
+const rowify = docs => ({ rows: docs.map(doc => ({ id: doc._id, doc: doc })) });
+
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.onCall(0).callsArgWith(1, null, rowify(fetchedParents));
+fetch.onCall(1).callsArgWith(1, null, rowify(fetchedContacts));
+
+lineage.hydrateDocs(docs).then(([ hydratedReport, hydratedPlace ]) => {
+  test.equals(fetch.callCount, 2);
+  test.deepEqual(fetch.args[0][0].keys.sort(), fetchedParents.map(doc => doc._id).sort());
+  test.deepEqual(fetch.args[1][0].keys.sort(), fetchedContacts.map(doc => doc._id).sort());
+
+  test.equals(hydratedReport.contact.name, report_contact.name);
+  test.equals(hydratedReport.parent, null);
+  test.equals(hydratedReport.contact.parent.name, report_parent.name);
+  test.equals(hydratedReport.contact.parent.contact.name, report_parentContact.name);
+  test.equals(hydratedReport.contact.parent.parent.name, report_grandparent.name);
+  test.equals(hydratedReport.contact.parent.parent.contact.name, report_grandparentContact.name);
+
+  test.equals(hydratedPlace.contact.name, place_contact.name);
+  test.equals(hydratedPlace.parent.name, place_parent.name);
+  test.equals(hydratedPlace.parent.contact.name, place_parentContact.name);
+  test.equals(hydratedPlace.parent.parent.name, place_grandparent.name);
+  test.equals(hydratedPlace.parent.parent.contact.name, place_grandparentContact.name);
+
+  test.done();
+}).catch(test.done);
 };
 
 exports['hydrateDocs works on empty array'] = test => {
-  const docs = [];
-  lineage.hydrateDocs(docs).then((hydratedDocs) => {
-    test.equals(hydratedDocs.length, 0);
-    test.done();
-  });
+const docs = [];
+lineage.hydrateDocs(docs).then((hydratedDocs) => {
+  test.equals(hydratedDocs.length, 0);
+  test.done();
+});
 };
 
 exports['hydrateDocs works on docs without contacts or parents'] = test => {
-  const docs = [
-    { _id: 'a' },
-    { _id: 'b' },
-  ];
-  lineage.hydrateDocs(docs).then((hydratedDocs) => {
-    test.deepEqual(hydratedDocs, docs);
-    test.done();
-  });
+const docs = [
+  { _id: 'a' },
+  { _id: 'b' },
+];
+lineage.hydrateDocs(docs).then((hydratedDocs) => {
+  test.deepEqual(hydratedDocs, docs);
+  test.done();
+});
+};
+
+exports['hydrateDocs+minify is noop'] = test => {
+const docs = [ report, place ];
+
+const fetchedParents = [ report_parent, report_grandparent, report_contact, place_parent, place_grandparent ];
+const fetchedContacts = [ report_parentContact, report_grandparentContact, place_contact, place_parentContact, place_grandparentContact ];
+const rowify = docs => ({ rows: docs.map(doc => ({ id: doc._id, doc: doc })) });
+
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.onCall(0).callsArgWith(1, null, rowify(fetchedParents));
+fetch.onCall(1).callsArgWith(1, null, rowify(fetchedContacts));
+
+lineage.hydrateDocs(docs).then(([ hydratedReport, hydratedPlace ]) => {
+  lineage.minify(hydratedReport);
+  lineage.minify(hydratedPlace);
+  test.deepEqual(hydratedReport, report);
+  test.deepEqual(hydratedPlace, place);
+  test.done();
+});
+};
+
+exports['hydrateDocs ignores db-fetch errors'] = test => {
+const docs = [ report, place ];
+
+const fetchedParents = [ report_parent, report_grandparent, report_contact, place_parent, place_grandparent ];
+const fetchedContacts = [ report_parentContact, report_grandparentContact, place_contact, place_parentContact, place_grandparentContact ];
+const rowify = docs => ({ rows: docs.map(doc => ({ id: doc._id, doc: doc })) });
+
+const fetchedParentsRows = rowify(fetchedParents);
+fetchedParentsRows.rows[3].doc = null; // place_parent
+const fetchedContactsRows = rowify(fetchedContacts);
+fetchedContactsRows.rows[0].doc = null; // report_parentContact
+
+const fetch = sinon.stub(db.medic, 'fetch');
+fetch.onCall(0).callsArgWith(1, null, fetchedParentsRows);
+fetch.onCall(1).callsArgWith(1, null, fetchedContactsRows);
+
+lineage.hydrateDocs(docs).then(([ hydratedReport, hydratedPlace ]) => {
+  test.equals(hydratedReport.contact.name, report_contact.name);
+  test.equals(hydratedReport.parent, null);
+  test.equals(hydratedReport.contact.parent.name, report_parent.name);
+  test.equals(hydratedReport.contact.parent.contact._id, report_parentContact._id);
+  test.equals(hydratedReport.contact.parent.contact.name, null); // db-fetch error : not hydrated
+  test.equals(hydratedReport.contact.parent.parent.name, report_grandparent.name);
+  test.equals(hydratedReport.contact.parent.parent.contact.name, report_grandparentContact.name);
+
+  test.equals(hydratedPlace.contact.name, place_contact.name);
+  test.equals(hydratedPlace.parent._id, place_parent._id);
+  test.equals(hydratedPlace.parent.name, null); // db-fetch error : not hydrated
+  test.equals(hydratedPlace.parent.contact, null); // db-fetch error : not hydrated
+  test.equals(hydratedPlace.parent.parent.name, place_grandparent.name);
+  test.equals(hydratedPlace.parent.parent.contact.name, place_grandparentContact.name);
+
+  test.done();
+}).catch(test.done);
+
 };


### PR DESCRIPTION
# Description
Edit the bulk hydration of docs to using the right doc structure for data_records. They don't have a parent field.
See test's `setUp` for the right data structure. Refactored the test to reuse that data (we had the single-doc function doing something different than the bulk function...)

medic/medic-webapp#3789

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
