### PR TITLE
multi_report_alerts : Run the latest_report through the is_report_counted function

### DIFF
--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -498,3 +498,27 @@ exports['skips doc with wrong form if forms is present in config'] = test => {
     test.done();
   });
 };
+
+exports['latest report has to pass is_report_counted function'] = test => {
+  alert.is_report_counted = 'function(report, latestReport) { return report.form === "B"; }';
+  alert.num_reports_threshold = 2;
+  sinon.stub(config, 'get').returns([alert]);
+
+  // Only 1 report has form B, the latest_report doesn't, so we shouldn't pass the num_reports_threshold.
+  // (pre-asserting the test data so that we don't break this test later by accident)
+  test.equals(doc.form, 'A');
+  test.equals(reports.filter(report => report.form === 'B').length, 1);
+
+  sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
+  stubFetchHydratedDocs();
+  sinon.stub(messages, 'addError');
+  sinon.stub(messages, 'addMessage');
+
+  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+    test.equals(messages.addError.getCalls().length, 0);
+    test.equals(messages.addMessage.getCalls().length, 0);
+    test.ok(!err);
+    test.ok(!docNeedsSaving);
+    test.done();
+  });
+};

--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -499,12 +499,12 @@ exports['skips doc with wrong form if forms is present in config'] = test => {
   });
 };
 
-exports['latest report has to pass is_report_counted function'] = test => {
+exports['latest report has to go through is_report_counted function'] = test => {
   alert.is_report_counted = 'function(report, latestReport) { return report.form === "B"; }';
   alert.num_reports_threshold = 2;
   sinon.stub(config, 'get').returns([alert]);
 
-  // Only 1 report has form B, the latest_report doesn't, so we shouldn't pass the num_reports_threshold.
+  // Only 1 report has form B, the latest_report doesn't, so we shouldn't reach the num_reports_threshold.
   // (pre-asserting the test data so that we don't break this test later by accident)
   test.equals(doc.form, 'A');
   test.equals(reports.filter(report => report.form === 'B').length, 1);

--- a/transitions/multi_report_alerts.js
+++ b/transitions/multi_report_alerts.js
@@ -194,6 +194,12 @@ const getCountedReportsAndPhones = (alert, latestReport) => {
   return new Promise((resolve, reject) => {
     const script = vm.createScript(`(${alert.is_report_counted})(report, latestReport)`);
     let skip = 0;
+
+    if (!countReports([latestReport], latestReport, script).length) {
+      // The latest_report didn't pass the is_report_counted function, abort the transition.
+      return resolve({ countedReportsIds: [], newReports: [], phones: [] });
+    }
+
     let countedReportsIds = [ latestReport._id ];
     let newReports = [ latestReport ];
     let phones = getPhonesOneReport(alert.recipients, latestReport);


### PR DESCRIPTION
# Description

All reports should be tested by is_report_counted function, including the latest one that triggered the transition.

medic/medic-webapp#3793

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
