### PR TITLE
Schedules are messing with each other due to bad management of groups

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -304,6 +304,61 @@ const getPatient = (db, patientShortcodeId, includeDocs, callback) => {
   });
 };
 
+/*
+ * type can be array or string
+ */
+const getScheduledTasksByType = (doc, type) => {
+  const scheduled_tasks = doc && doc.scheduled_tasks;
+  return _.filter(scheduled_tasks, task => {
+    if (_.isArray(type)) {
+      return type.indexOf(task.type) >= 0;
+    }
+    return task.type === type;
+  });
+};
+
+/*
+ * Return false when the recipient phone matches the denied list.
+ *
+ * outgoing_deny_list is a comma separated list of strings. If a string in
+ * that list matches the beginning of the phone then we set up a response
+ * with a denied state. The pending message process will ignore these
+ * messages and those reports will be left without an auto-reply. The
+ * denied messages still show up in the messages export.
+ *
+ * @param {String} from - Recipient phone number
+ * @returns {Boolean}
+ */
+const isOutgoingAllowed = from => {
+  const conf = config.get('outgoing_deny_list') || '';
+  if (!from) {
+    return true;
+  }
+  if (_isMessageFromGateway(from)) {
+    return false;
+  }
+  return _.every(conf.split(','), s => {
+    // ignore falsey inputs
+    if (!s) {
+      return true;
+    }
+    // return false if we get a case insensitive starts with match
+    return from.toLowerCase().indexOf(s.trim().toLowerCase()) !== 0;
+  });
+};
+
+/*
+ * Used to avoid infinite loops of auto-reply messages between gateway and
+ * itself.
+ */
+const _isMessageFromGateway = from => {
+  const gw = config.get('gateway_number');
+  if (typeof gw === 'string' && typeof from === 'string') {
+    return phoneUtil.isNumberMatch(gw, from) >= 3;
+  }
+  return false;
+};
+
 module.exports = {
   getVal: getVal,
   getLocale: getLocale,
@@ -330,20 +385,9 @@ module.exports = {
     }
     return 'health volunteer';
   },
-  /*
-   * type can be array or string
-   */
-  filterScheduledMessages: (doc, type) => {
-    const scheduled_tasks = doc && doc.scheduled_tasks;
-    return _.filter(scheduled_tasks, task => {
-      if (_.isArray(type)) {
-        return type.indexOf(task.type) >= 0;
-      }
-      return task.type === type;
-    });
-  },
+  getScheduledTasksByType: getScheduledTasksByType,
   findScheduledMessage: (doc, type) => {
-    return _.first(module.exports.filterScheduledMessages(doc, type));
+    return _.first(getScheduledTasksByType(doc, type));
   },
   updateScheduledMessage: (doc, options) => {
     if (!options || !options.message || !options.type) {
@@ -358,7 +402,6 @@ module.exports = {
   },
   addScheduledMessage: (doc, options) => {
     options = options || {};
-    const self = module.exports;
 
     if (options.due instanceof Date) {
       options.due = options.due.getTime();
@@ -367,7 +410,7 @@ module.exports = {
     const task = _.omit(options, 'message', 'phone');
     task.messages = createTaskMessages(options);
 
-    if (!self.isOutgoingAllowed(doc.from)) {
+    if (!isOutgoingAllowed(doc.from)) {
       setTaskState(task, 'denied');
     } else {
       setTaskState(task, 'scheduled');
@@ -474,36 +517,7 @@ module.exports = {
   escapeRegex: string => {
     return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
   },
-  /*
-   * Return false when the recipient phone matches the denied list.
-   *
-   * outgoing_deny_list is a comma separated list of strings. If a string in
-   * that list matches the beginning of the phone then we set up a response
-   * with a denied state. The pending message process will ignore these
-   * messages and those reports will be left without an auto-reply. The
-   * denied messages still show up in the messages export.
-   *
-   * @param {String} from - Recipient phone number
-   * @returns {Boolean}
-   */
-  isOutgoingAllowed: from => {
-    const self = module.exports,
-      conf = config.get('outgoing_deny_list') || '';
-    if (!from) {
-      return true;
-    }
-    if (self._isMessageFromGateway(from)) {
-      return false;
-    }
-    return _.every(conf.split(','), s => {
-      // ignore falsey inputs
-      if (!s) {
-        return true;
-      }
-      // return false if we get a case insensitive starts with match
-      return from.toLowerCase().indexOf(s.trim().toLowerCase()) !== 0;
-    });
-  },
+  isOutgoingAllowed: isOutgoingAllowed,
   /*
    * Given a patient "shortcode" (as used in SMS reports), return the _id
    * of the patient's person contact to the caller
@@ -518,16 +532,5 @@ module.exports = {
   getPatientContact: (db, patientShortcodeId, callback) => {
     getPatient(db, patientShortcodeId, true, callback);
   },
-  /*
-   * Used to avoid infinite loops of auto-reply messages between gateway and
-   * itself.
-   */
-  _isMessageFromGateway: from => {
-    const gw = config.get('gateway_number');
-    if (typeof gw === 'string' && typeof from === 'string') {
-      return phoneUtil.isNumberMatch(gw, from) >= 3;
-    }
-    return false;
-  }
-
+  _isMessageFromGateway: _isMessageFromGateway
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -305,16 +305,14 @@ const getPatient = (db, patientShortcodeId, includeDocs, callback) => {
 };
 
 /*
- * type can be array or string
+ * type is a string
  */
 const getScheduledTasksByType = (doc, type) => {
   const scheduled_tasks = doc && doc.scheduled_tasks;
-  return _.filter(scheduled_tasks, task => {
-    if (_.isArray(type)) {
-      return type.indexOf(task.type) >= 0;
-    }
-    return task.type === type;
-  });
+  if (!scheduled_tasks || !scheduled_tasks.length) {
+    return [];
+  }
+  return scheduled_tasks.filter(task => task.type === type );
 };
 
 /*
@@ -386,9 +384,6 @@ module.exports = {
     return 'health volunteer';
   },
   getScheduledTasksByType: getScheduledTasksByType,
-  findScheduledMessage: (doc, type) => {
-    return _.first(getScheduledTasksByType(doc, type));
-  },
   updateScheduledMessage: (doc, options) => {
     if (!options || !options.message || !options.type) {
       return;

--- a/test/functional/validations.js
+++ b/test/functional/validations.js
@@ -1,4 +1,5 @@
-var sinon = require('sinon').sandbox.create(),
+var config = require('../../config'),
+    sinon = require('sinon').sandbox.create(),
     utils = require('../../lib/utils'),
     transition = require('../../transitions/accept_patient_reports');
 
@@ -19,7 +20,7 @@ exports['patient id failing validation adds error'] = function(test) {
         form: 'x'
     };
 
-    sinon.stub(transition, 'getAcceptedReports').returns([{
+    sinon.stub(config, 'get').withArgs('patient_reports').returns([{
         validations: {
             list: [{
                 property: 'patient_id',
@@ -54,7 +55,7 @@ exports['validations use translation_key'] = function(test) {
         form: 'x'
     };
 
-    sinon.stub(transition, 'getAcceptedReports').returns([{
+    sinon.stub(config, 'get').withArgs('patient_reports').returns([{
         validations: {
             list: [{
                 property: 'patient_id',
@@ -85,7 +86,7 @@ exports['join responses concats validation response msgs'] = function(test) {
         form: 'x'
     };
 
-    sinon.stub(transition, 'getAcceptedReports').returns([{
+    sinon.stub(config, 'get').withArgs('patient_reports').returns([{
         validations: {
             join_responses: true,
             list: [
@@ -144,7 +145,7 @@ exports['false join_responses does not concat validation msgs'] = function(test)
         form: 'x'
     };
 
-    sinon.stub(transition, 'getAcceptedReports').returns([{
+    sinon.stub(config, 'get').withArgs('patient_reports').returns([{
         validations: {
             join_responses: false,
             list: [
@@ -202,7 +203,7 @@ exports['undefined join_responses does not concat validation msgs'] = function(t
         form: 'x'
     };
 
-    sinon.stub(transition, 'getAcceptedReports').returns([{
+    sinon.stub(config, 'get').withArgs('patient_reports').returns([{
         validations: {
             list: [
                 {

--- a/test/unit/accept_patient_reports.js
+++ b/test/unit/accept_patient_reports.js
@@ -1,4 +1,5 @@
 var _ = require('underscore'),
+    config = require('../../config'),
     moment = require('moment'),
     sinon = require('sinon').sandbox.create(),
     transition = require('../../transitions/accept_patient_reports'),
@@ -18,7 +19,7 @@ exports['filter validation'] = function(test) {
 };
 
 exports['onMatch callback empty if form not included'] = function(test) {
-    sinon.stub(transition, 'getAcceptedReports').returns([ { form: 'x' }, { form: 'z' } ]);
+    sinon.stub(config, 'get').returns([ { form: 'x' }, { form: 'z' } ]);
 
     transition.onMatch({
         doc: {
@@ -31,12 +32,13 @@ exports['onMatch callback empty if form not included'] = function(test) {
     });
 };
 
-exports['onMatch with matching form calls getRegistrations and then matchRegistrations'] = function(test) {
-    sinon.stub(transition, 'getAcceptedReports').returns([ { form: 'x' }, { form: 'z' } ]);
+exports['onMatch with matching form calls getRegistrations and then getPatientContact and then getLocale'] = function(test) {
+    sinon.stub(config, 'get').returns([ { form: 'x', messages: [] }, { form: 'z' } ]);
 
     var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []),
-        getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, { _id: 'uuid', name: 'sally' }),
-        matchRegistrations = sinon.stub(transition, 'matchRegistrations').callsArgWith(1, null, true);
+        getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, { _id: 'uuid', name: 'sally' });
+
+    const getLocale = sinon.stub(utils, 'getLocale').returns('en');
 
     transition.onMatch({
         doc: {
@@ -50,17 +52,16 @@ exports['onMatch with matching form calls getRegistrations and then matchRegistr
         test.equal(getPatientContact.called, true);
         test.equal(getPatientContact.callCount, 1);
         test.equal(getPatientContact.args[0][1], 'x');
-        test.equal(matchRegistrations.called, true);
+        test.equal(getLocale.called, true);
 
         test.done();
     });
 };
 
 exports['onMatch with no patient id adds error msg and response'] = function(test) {
-    sinon.stub(transition, 'getAcceptedReports').returns([ { form: 'x' }, { form: 'z' } ]);
+    sinon.stub(config, 'get').returns([ { form: 'x' }, { form: 'z' } ]);
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
     sinon.stub(utils, 'getPatientContact').callsArgWith(2);
-    sinon.stub(transition, 'matchRegistrations').callsArgWith(1, null, true);
 
     var doc = {
         form: 'x',
@@ -79,34 +80,37 @@ exports['onMatch with no patient id adds error msg and response'] = function(tes
 
 // Because patients can be created through the UI and not neccessarily have
 // a registration at all
-exports['matchRegistrations with no registrations does not error'] = function(test) {
-
+exports['handleReport with no registrations does not error'] = function(test) {
     var doc = {
         fields: { patient_id: 'x' },
         from: '+123'
     };
+    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    const config = {
+        messages: [{
+            event_type: 'registration_not_found',
+            message: [{
+                content: 'not found {{patient_id}}',
+                locale: 'en'
+            }],
+            recipient: 'reporting_unit'
+        }]
+    };
 
-    transition.matchRegistrations({
-        registrations: [],
-        doc: doc,
-        report: {
-            messages: [{
-                event_type: 'registration_not_found',
-                message: [{
-                    content: 'not found {{patient_id}}',
-                    locale: 'en'
-                }],
-                recipient: 'reporting_unit'
-            }]
-        }
-    }, function() {
-        test.ok(!doc.errors);
-        test.ok(!doc.tasks);
-        test.done();
-    });
+    transition.handleReport(
+        null,
+        null,
+        doc,
+        null,
+        config,
+        function() {
+            test.ok(!doc.errors);
+            test.ok(!doc.tasks);
+            test.done();
+        });
 };
 
-exports['matchRegistrations with patient adds reply'] = function(test) {
+exports['handleReport with patient adds reply'] = function(test) {
     var doc = {
         fields: { patient_id: '559' },
         contact: {
@@ -120,53 +124,61 @@ exports['matchRegistrations with patient adds reply'] = function(test) {
             }
         }
     };
-
-    transition.matchRegistrations({
-        patient: { patient_name: 'Archibald' },
-        doc: doc,
-        report: {
-            messages: [{
-                event_type: 'report_accepted',
-                message: [{
-                    content: 'Thank you, {{contact.name}}. ANC visit for {{patient_name}} ({{patient_id}}) has been recorded.',
-                    locale: 'en'
-                }],
-                recipient: 'reporting_unit'
-            }]
-        }
-    }, function() {
-        test.ok(doc.tasks);
-        test.equal(
-            _.first(_.first(doc.tasks).messages).message,
-            'Thank you, woot. ANC visit for Archibald (559) has been recorded.'
-        );
-        test.done();
-    });
+    const patient = { patient_name: 'Archibald' };
+    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
+    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    const config = {
+        messages: [{
+            event_type: 'report_accepted',
+            message: [{
+                content: 'Thank you, {{contact.name}}. ANC visit for {{patient_name}} ({{patient_id}}) has been recorded.',
+                locale: 'en'
+            }],
+            recipient: 'reporting_unit'
+        }]
+    };
+    transition.handleReport(
+        null,
+        null,
+        doc,
+        patient,
+        config,
+        function() {
+            test.ok(doc.tasks);
+            test.equal(
+                _.first(_.first(doc.tasks).messages).message,
+                'Thank you, woot. ANC visit for Archibald (559) has been recorded.'
+            );
+            test.done();
+        });
 };
 
-exports['adding silence_type to matchRegistrations calls silenceReminders'] = function(test) {
-    sinon.stub(transition, 'silenceReminders').callsArgWith(1);
-
-    transition.matchRegistrations({
-        doc: { _id: 'a' },
-        registrations: [
-            { id: 'a' }, // should not be silenced as it's the doc being processed
-            { id: 'b' }, // should be silenced
-            { id: 'c' }  // should be silenced
-        ],
-        report: {
-            silence_type: 'x'
-        }
-    }, function(err, complete) {
-        test.equals(complete, true);
-        test.equals(transition.silenceReminders.callCount, 2);
-        test.equals(transition.silenceReminders.args[0][0].registration.id, 'b');
-        test.equals(transition.silenceReminders.args[1][0].registration.id, 'c');
-        test.done();
-    });
+exports['adding silence_type to handleReport calls _silenceReminders'] = function(test) {
+    sinon.stub(transition, '_silenceReminders').callsArgWith(4);
+    const doc = { _id: 'a' };
+    const config = { silence_type: 'x' };
+    const registrations = [
+        { doc: { id: 'a' } }, // should not be silenced as it's the doc being processed
+        { doc: { id: 'b' } }, // should be silenced
+        { doc: { id: 'c' } }  // should be silenced
+    ];
+    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
+    transition.handleReport(
+        null,
+        null,
+        doc,
+        null,
+        config,
+        function(err, complete) {
+            test.equals(complete, true);
+            test.equals(transition._silenceReminders.callCount, 2);
+            test.equals(transition._silenceReminders.args[0][1].id, 'b');
+            test.equals(transition._silenceReminders.args[1][1].id, 'c');
+            test.done();
+        });
 };
 
-exports['silenceReminders testing'] = function(test) {
+exports['_silenceReminders testing'] = function(test) {
     var audit = { saveDoc: function() {} },
         now = moment(),
         registration;
@@ -175,239 +187,222 @@ exports['silenceReminders testing'] = function(test) {
 
     // mock up a registered_patients view result
     registration = {
-        doc: {
-            scheduled_tasks: [
-                {
-                    due: now.clone().subtract(5, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().subtract(2, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(10, 'days').toISOString(),
-                    group: 2,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(12, 'days').toISOString(),
-                    group: 2,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(12, 'days').toISOString(),
-                    group: 2,
-                    state: 'scheduled',
-                    // a different type, should be ignored
-                    type: 'y'
-                },
-                {
-                    due: now.clone().add(20, 'days').toISOString(),
-                    group: 3,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(25, 'days').toISOString(),
-                    group: 3,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                // last one is out of order
-                {
-                    due: now.clone().add(7, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'x'
-                }
-            ]
-        }
+        scheduled_tasks: [
+            {
+                due: now.clone().subtract(5, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().subtract(2, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(10, 'days').toISOString(),
+                group: 2,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(12, 'days').toISOString(),
+                group: 2,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(12, 'days').toISOString(),
+                group: 2,
+                state: 'scheduled',
+                // a different type, should be ignored
+                type: 'y'
+            },
+            {
+                due: now.clone().add(20, 'days').toISOString(),
+                group: 3,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(25, 'days').toISOString(),
+                group: 3,
+                state: 'scheduled',
+                type: 'x'
+            },
+            // last one is out of order
+            {
+                due: now.clone().add(7, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'x'
+            }
+        ]
     };
+    const config = { silence_type: 'x', silence_for: '15 days'};
+    const reported_date = now.valueOf();
 
-    transition.silenceReminders({
-        audit: audit,
-        registration: registration,
-        type: 'x',
-        reported_date: now.valueOf(),
-        silence_for: '15 days'
-    }, function(err) {
-        var tasks;
+    transition._silenceReminders(
+        audit, registration, reported_date, config,
+        function(err) {
+            var tasks;
 
-        test.equal(err, null);
+            test.equal(err, null);
 
-        test.equal(audit.saveDoc.called, true);
+            test.equal(audit.saveDoc.called, true);
 
-        tasks = registration.doc.scheduled_tasks;
+            tasks = registration.scheduled_tasks;
 
-        test.equal(tasks[0].state, 'scheduled');
-        test.equal(tasks[1].state, 'scheduled');
-        test.equal(tasks[2].state, 'cleared');
-        test.equal(tasks[2].state_history[0].state, 'cleared');
-        test.equal(tasks[3].state, 'cleared');
-        test.equal(tasks[3].state_history[0].state, 'cleared');
-        test.equal(tasks[4].state, 'scheduled');
-        test.equal(tasks[5].state, 'scheduled');
-        test.equal(tasks[6].state, 'scheduled');
+            test.equal(tasks[0].state, 'scheduled');
+            test.equal(tasks[1].state, 'scheduled');
+            test.equal(tasks[2].state, 'cleared');
+            test.equal(tasks[2].state_history[0].state, 'cleared');
+            test.equal(tasks[3].state, 'cleared');
+            test.equal(tasks[3].state_history[0].state, 'cleared');
+            test.equal(tasks[4].state, 'scheduled');
+            test.equal(tasks[5].state, 'scheduled');
+            test.equal(tasks[6].state, 'scheduled');
 
-        test.done();
-    });
+            test.done();
+        });
 };
 
 exports['empty silence_for option clears all reminders'] = function(test) {
     var audit = { saveDoc: function() {} },
-        now = moment(),
-        registration;
+        now = moment();
 
     sinon.stub(audit, 'saveDoc').callsArgWith(1, null);
 
     // mock up a registered_patients view result
-    registration = {
-        doc: {
-            scheduled_tasks: [
-                {
-                    due: now.clone().subtract(2, 'days'),
-                    group: 0,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(2, 'days'),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(2, 'days'),
-                    group: 2,
-                    state: 'scheduled',
-                    type: 'y'
-                },
-                {
-                    due: now.clone().add(20, 'days'),
-                    group: 2,
-                    state: 'scheduled',
-                    type: 'x'
-                },
-                {
-                    due: now.clone().add(2, 'days'),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'x'
-                }
-            ]
-        }
+    const registration = {
+        scheduled_tasks: [
+            {
+                due: now.clone().subtract(2, 'days'),
+                group: 0,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(2, 'days'),
+                group: 1,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(2, 'days'),
+                group: 2,
+                state: 'scheduled',
+                type: 'y'
+            },
+            {
+                due: now.clone().add(20, 'days'),
+                group: 2,
+                state: 'scheduled',
+                type: 'x'
+            },
+            {
+                due: now.clone().add(2, 'days'),
+                group: 1,
+                state: 'scheduled',
+                type: 'x'
+            }
+        ]
     };
+    const reported_date = now.clone().toISOString();
+    const config = { silence_type: 'x', silence_for: '' };
+    transition._silenceReminders(
+        audit, registration, reported_date, config,
+        function(err) {
+            var tasks;
 
-    transition.silenceReminders({
-        audit: audit,
-        registration: registration,
-        type: 'x',
-        reported_date: now.clone().toISOString(),
-        silence_for: ''
-    }, function(err) {
-        var tasks;
+            test.equal(err, null);
 
-        test.equal(err, null);
+            test.equal(audit.saveDoc.called, true);
 
-        test.equal(audit.saveDoc.called, true);
+            tasks = registration.scheduled_tasks;
 
-        tasks = registration.doc.scheduled_tasks;
+            // don't clear in the past
+            test.equal(tasks[0].state, 'scheduled');
 
-        // don't clear in the past
-        test.equal(tasks[0].state, 'scheduled');
+            // only clear schedule of the same type
+            test.equal(tasks[2].state, 'scheduled');
 
-        // only clear schedule of the same type
-        test.equal(tasks[2].state, 'scheduled');
+            test.equal(tasks[1].state, 'cleared');
+            test.equal(tasks[1].state_history[0].state, 'cleared');
+            test.equal(tasks[3].state, 'cleared');
+            test.equal(tasks[4].state, 'cleared');
+            test.equal(tasks[4].state_history[0].state, 'cleared');
 
-        test.equal(tasks[1].state, 'cleared');
-        test.equal(tasks[1].state_history[0].state, 'cleared');
-        test.equal(tasks[3].state, 'cleared');
-        test.equal(tasks[4].state, 'cleared');
-        test.equal(tasks[4].state_history[0].state, 'cleared');
-
-        test.done();
+            test.done();
     });
 };
 
 exports['when silence_type is comma separated act on multiple schedules'] = function(test) {
     var audit = { saveDoc: function() {} },
-        now = moment(),
-        registration;
+        now = moment();
 
     sinon.stub(audit, 'saveDoc').callsArgWith(1, null);
 
     // mock up a registered_patients view result
-    registration = {
-        doc: {
-            scheduled_tasks: [
-                {
-                    due: now.clone().subtract(2, 'days').toISOString(),
-                    group: 0,
-                    state: 'scheduled',
-                    type: 'foo'
-                },
-                {
-                    due: now.clone().add(2, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'foo'
-                },
-                {
-                    due: now.clone().add(2, 'days').toISOString(),
-                    group: 2,
-                    state: 'scheduled',
-                    type: 'foo'
-                },
-                {
-                    due: now.clone().add(2, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'bar'
-                },
-                {
-                    due: now.clone().add(5, 'days').toISOString(),
-                    group: 1,
-                    state: 'scheduled',
-                    type: 'bar'
-                }
-            ]
-        }
+    const registration = {
+        scheduled_tasks: [
+            {
+                due: now.clone().subtract(2, 'days').toISOString(),
+                group: 0,
+                state: 'scheduled',
+                type: 'foo'
+            },
+            {
+                due: now.clone().add(2, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'foo'
+            },
+            {
+                due: now.clone().add(2, 'days').toISOString(),
+                group: 2,
+                state: 'scheduled',
+                type: 'foo'
+            },
+            {
+                due: now.clone().subtract(2, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'bar'
+            },
+            {
+                due: now.clone().add(5, 'days').toISOString(),
+                group: 1,
+                state: 'scheduled',
+                type: 'bar'
+            }
+        ]
     };
 
-    transition.silenceReminders({
-        audit: audit,
-        registration: registration,
-        type: 'foo, bar',
-        reported_date: now.clone().toISOString(),
-        silence_for: ''
-    }, function(err) {
-        var tasks;
+    const config = { silence_type: 'foo, bar', silence_for: '' };
+    const reported_date = now.clone().toISOString();
+    transition._silenceReminders(
+        audit, registration, reported_date, config,
+        function(err) {
+            test.equal(err, null);
 
-        test.equal(err, null);
+            test.equal(audit.saveDoc.called, true);
 
-        test.equal(audit.saveDoc.called, true);
+            const tasks = registration.scheduled_tasks;
 
-        tasks = registration.doc.scheduled_tasks;
+            // don't clear in the past
+            test.equal(tasks[0].state, 'scheduled');
 
-        // don't clear in the past
-        test.equal(tasks[0].state, 'scheduled');
+            test.equal(tasks[1].state, 'cleared');
+            test.equal(tasks[1].state_history[0].state, 'cleared');
+            test.equal(tasks[2].state, 'cleared');
+            test.equal(tasks[2].state_history[0].state, 'cleared');
+            // don't clear in the past
+            test.equal(tasks[3].state, 'scheduled');
+            test.equal(tasks[4].state, 'cleared');
+            test.equal(tasks[4].state_history[0].state, 'cleared');
 
-        test.equal(tasks[1].state, 'cleared');
-        test.equal(tasks[1].state_history[0].state, 'cleared');
-        test.equal(tasks[2].state, 'cleared');
-        test.equal(tasks[2].state_history[0].state, 'cleared');
-        test.equal(tasks[3].state, 'cleared');
-        test.equal(tasks[3].state_history[0].state, 'cleared');
-        test.equal(tasks[4].state, 'cleared');
-        test.equal(tasks[4].state_history[0].state, 'cleared');
-
-        test.done();
-    });
+            test.done();
+        });
 };


### PR DESCRIPTION
# Description

Silence schedules one by one rather than all together, to fix a bug where schedules' clearing was influencing other schedules' clearing. 
See test that fails because of bug : https://github.com/medic/medic-sentinel/pull/163/commits/bca9411c64e3c87a3284b5f314079a11b8c3dae6

medic/medic-webapp#3824

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
