### PR TITLE
Don't escape template parameters

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -4,6 +4,10 @@ var mustache = require('mustache'),
     config = require('../config'),
     toBikramSambatLetters = require('bikram-sambat').toBik_text;
 
+mustache.escape = function(value) {
+  return value;
+};
+
 var configuredFormat = function(date, key) {
   return format(date, config.get(key));
 };

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -144,6 +144,25 @@ exports['addMessage supports template variables on doc'] = function(test) {
     test.done();
 };
 
+exports['addMessage does not escape characters - #3795'] = function(test) {
+    var doc = {
+        form: 'x',
+        reported_date: '2050-03-13T13:06:22.002Z',
+        place: 'Sharon\'s Place'
+    };
+    messages.addMessage({
+        doc: doc,
+        phone: '+13125551212',
+        message: 'You\'re from {{place}}'
+    });
+    test.equals(doc.tasks.length, 1);
+    test.equals(
+        doc.tasks[0].messages[0].message,
+        'You\'re from Sharon\'s Place'
+    );
+    test.done();
+};
+
 exports['addMessage template supports contact obj'] = function(test) {
     var doc = {
         form: 'x',

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -148,7 +148,7 @@ exports['addMessage does not escape characters - #3795'] = function(test) {
     var doc = {
         form: 'x',
         reported_date: '2050-03-13T13:06:22.002Z',
-        place: 'Sharon\'s Place'
+        place: 'Sharon\'s Place &<>"/`='
     };
     messages.addMessage({
         doc: doc,
@@ -158,7 +158,7 @@ exports['addMessage does not escape characters - #3795'] = function(test) {
     test.equals(doc.tasks.length, 1);
     test.equals(
         doc.tasks[0].messages[0].message,
-        'You\'re from Sharon\'s Place'
+        'You\'re from Sharon\'s Place &<>"/`='
     );
     test.done();
 };


### PR DESCRIPTION
# Description

Mustache escape HTML characters by default because usually it's
used for displaying HTML content so it's at risk for injection.
We just use it for generating SMS messages to HTML escaping isn't
relevant for us. We use angular to escaping the message content
when displayed in the webapp.

medic/medic-webapp#3795

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
