### PR TITLE
Fix issues with missing {{patient_name}}

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -12,21 +12,16 @@ function extendedTemplateContext(doc, extras) {
 
     if (extras.patient) {
         _.defaults(templateContext, module.exports.extractTemplateContext(extras.patient));
+
+        // Don't want to add this to extractTemplateContext as 'name' is too generic
+        // and eTC gets called elsewhere
+        templateContext.patient_name = templateContext.patient_name || extras.patient.name;
     }
 
     if (extras.registrations && extras.registrations.length) {
         _.defaults(templateContext, module.exports.extractTemplateContext(extras.registrations[0]));
     }
 
-    if (extras.person) {
-        templateContext.person = extras.person;
-
-        // For backwards compatibilty. Configurers are used to the patient's
-        // name being available here, so alias it for now. This could be dropped
-        // in a future major release if we ever decide to revisit and
-        // standardise how we expose data to the message templater.
-        templateContext.patient_name = templateContext.patient_name || templateContext.person.name;
-    }
 
     return templateContext;
 }
@@ -38,7 +33,6 @@ function extendedTemplateContext(doc, extras) {
  * - phone (optional, will get clinic phone if absent)
  * - templateContext (optional)
  * - registrations (optional)
- * - person (optional)
  * - patient (optional)
  * - state (optional)
  * - taskFields (optional)
@@ -129,10 +123,10 @@ module.exports = {
         };
         return _.defaults(internal, doc.fields, doc);
     },
-    scheduleMessage: function(doc, msg, phone, registrations, person) {
+    scheduleMessage: function(doc, msg, phone, registrations, patient) {
         var templateContext = extendedTemplateContext(doc, {
             registrations: registrations,
-            person: person
+            patient: patient
         });
 
         phone = phone ? String(phone) : phone;

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -22,6 +22,12 @@ function extendedTemplateContext(doc, extras) {
         _.defaults(templateContext, module.exports.extractTemplateContext(extras.registrations[0]));
     }
 
+    if (!extras.patient && extras.registrations && extras.registrations.length) {
+        // If you're providing registrations to the template context you need to
+        // provide the patient contact document as well. Patients can be
+        // "registered" through the UI, only creating a patient and no registration report
+        throw Error('Cannot provide registrations to template context without a patient');
+    }
 
     return templateContext;
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -15,7 +15,7 @@ function extendedTemplateContext(doc, extras) {
     }
 
     if (extras.registrations && extras.registrations.length) {
-        _.defaults(templateContext, module.exports.extractTemplateContext(extras.registrations[0].doc));
+        _.defaults(templateContext, module.exports.extractTemplateContext(extras.registrations[0]));
     }
 
     if (extras.person) {

--- a/lib/schedules.js
+++ b/lib/schedules.js
@@ -63,7 +63,7 @@ module.exports = {
     /*
      * Take doc and schedule config and setup schedule tasks.
      */
-    assignSchedule: function(doc, schedule, registrations, person) {
+    assignSchedule: function(doc, schedule, registrations, patient) {
         var self = module.exports,
             docStart,
             start,
@@ -126,7 +126,7 @@ module.exports = {
                     group: msg.group,
                     type: schedule.name,
                     translation_key: schedule.translation_key
-                }, phone, registrations, person);
+                }, phone, registrations, patient);
             } else {
                 // bad offset, skip this msg
                 console.error(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -477,7 +477,7 @@ module.exports = {
       if (err) {
         return callback(err);
       }
-      callback(null, data.rows);
+      callback(null, data.rows.map(row => row.doc));
     });
   },
   getForm: formCode => {

--- a/test/functional/schedules.js
+++ b/test/functional/schedules.js
@@ -346,7 +346,7 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
         ]
     }]);
     sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
-    var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [ { doc: { fields: { patient_name: 'barry' } } } ]);
+    var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [ { fields: { patient_name: 'barry' } } ]);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
         start_from: 'reported_date',

--- a/test/unit/accept_patient_reports.js
+++ b/test/unit/accept_patient_reports.js
@@ -158,9 +158,9 @@ exports['adding silence_type to handleReport calls _silenceReminders'] = functio
     const doc = { _id: 'a' };
     const config = { silence_type: 'x' };
     const registrations = [
-        { doc: { id: 'a' } }, // should not be silenced as it's the doc being processed
-        { doc: { id: 'b' } }, // should be silenced
-        { doc: { id: 'c' } }  // should be silenced
+        { id: 'a' }, // should not be silenced as it's the doc being processed
+        { id: 'b' }, // should be silenced
+        { id: 'c' }  // should be silenced
     ];
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
     transition.handleReport(

--- a/test/unit/accept_patient_reports.js
+++ b/test/unit/accept_patient_reports.js
@@ -86,6 +86,8 @@ exports['handleReport with no registrations does not error'] = function(test) {
         from: '+123'
     };
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, {});
+
     const config = {
         messages: [{
             event_type: 'registration_not_found',
@@ -163,6 +165,7 @@ exports['adding silence_type to handleReport calls _silenceReminders'] = functio
         { id: 'c' }  // should be silenced
     ];
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
+    sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, {});
     transition.handleReport(
         null,
         null,

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -69,25 +69,7 @@ exports['scheduleMessage supports template variables on doc'] = function(test) {
     test.done();
 };
 
-exports['scheduleMessage lets you use info from a passed person'] = test => {
-    var doc = {
-        form: 'x',
-        reported_date: '2050-03-13T13:06:22.002Z',
-    };
-    var msg = {
-        message: 'Hello {{person.name}}.',
-        due: moment().toISOString()
-    };
-    messages.scheduleMessage(doc, msg, '+13125551212', [], {name: 'Sally'});
-    test.equals(doc.scheduled_tasks.length, 1);
-    test.equals(
-        doc.scheduled_tasks[0].messages[0].message,
-        'Hello Sally.'
-    );
-    test.done();
-};
-
-exports['scheduleMessage aliases person.name to patient_name for backwards compat'] = test => {
+exports['scheduleMessage aliases patient.name to patient_name'] = test => {
     var doc = {
         form: 'x',
         reported_date: '2050-03-13T13:06:22.002Z',
@@ -290,28 +272,12 @@ exports['addMessage template supports fields'] = function(test) {
     test.done();
 };
 
-exports['addMessage lets you use info from a passed person'] = test => {
+exports['addMessage aliases patient.name to patient_name'] = test => {
     const doc = {};
     messages.addMessage({
         doc: doc,
         phone: '123',
-        person: {name: 'Sally'},
-        message: 'Thank you {{person.name}}.',
-    });
-    test.equals(doc.tasks.length, 1);
-    test.equals(
-        doc.tasks[0].messages[0].message,
-        'Thank you Sally.'
-    );
-    test.done();
-};
-
-exports['addMessage aliases person.name to patient_name for backwards compat'] = test => {
-    const doc = {};
-    messages.addMessage({
-        doc: doc,
-        phone: '123',
-        person: {name: 'Sally'},
+        patient: {name: 'Sally'},
         message: 'Thank you {{patient_name}}.',
     });
     test.equals(doc.tasks.length, 1);

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -116,7 +116,8 @@ exports['scheduleMessage adds registration details to message context'] = functi
         due: moment().toISOString()
     };
     var registrations = [ { doc: { fields: { patient_name: 'Marc' } } } ];
-    messages.scheduleMessage(doc, msg, '+13125551212', registrations);
+    var person = { _id: '123', name: 'Marc' };
+    messages.scheduleMessage(doc, msg, '+13125551212', registrations, person);
     test.equals(doc.scheduled_tasks.length, 1);
     test.equals(
         doc.scheduled_tasks[0].messages[0].message,

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -97,9 +97,8 @@ exports['scheduleMessage adds registration details to message context'] = functi
         message: 'Dear {{patient_name}}, Governor {{governor}} wants to speak to you.',
         due: moment().toISOString()
     };
-    var registrations = [ { doc: { fields: { patient_name: 'Marc' } } } ];
     var person = { _id: '123', name: 'Marc' };
-    messages.scheduleMessage(doc, msg, '+13125551212', registrations, person);
+    messages.scheduleMessage(doc, msg, '+13125551212', [], person);
     test.equals(doc.scheduled_tasks.length, 1);
     test.equals(
         doc.scheduled_tasks[0].messages[0].message,

--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -625,14 +625,14 @@ exports['addMessage prepops and passes the right information to messages.addMess
   const testPhone = '1234',
         testMessage = 'A Test Message',
         testRegistration = 'some registrations',
-        testPerson = 'a patient contact';
+        testPatient = 'a patient contact';
 
   sinon.stub(messages, 'getRecipientPhone').returns(testPhone);
   sinon.stub(messages, 'getMessage').returns(testMessage);
   const addMessage = sinon.stub(messages, 'addMessage');
 
   sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, testRegistration);
-  sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPerson);
+  sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPatient);
 
   const testConfig = {
     messages: [{
@@ -657,7 +657,7 @@ exports['addMessage prepops and passes the right information to messages.addMess
       message: testMessage,
       templateContext: { next_msg: { minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0 } },
       registrations: testRegistration,
-      person: testPerson
+      patient: testPatient
     };
 
     test.deepEqual(addMessage.args[0][0], expected);

--- a/test/unit/update_notifications.js
+++ b/test/unit/update_notifications.js
@@ -308,10 +308,7 @@ exports['mute responds correctly'] = function(test) {
         off_form: 'off'
     });
 
-    sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [{
-        _id: 'x',
-        doc: regDoc
-    }]);
+    sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [regDoc]);
 
     var audit = {
         saveDoc: function(doc, callback) {

--- a/test/unit/update_notifications.js
+++ b/test/unit/update_notifications.js
@@ -208,6 +208,7 @@ exports['registration not found adds error and response'] = function(test) {
         on_form: 'on'
     });
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
+    sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, {});
 
     transition.onMatch({
         doc: doc,
@@ -309,6 +310,7 @@ exports['mute responds correctly'] = function(test) {
     });
 
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [regDoc]);
+    sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, []);
 
     var audit = {
         saveDoc: function(doc, callback) {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -555,12 +555,13 @@ exports['getPatientContact returns empty when no shortcode given'] = test => {
 };
 
 exports['getRegistrations queries by id if given'] = test => {
-    const expected = [ { id: 'a' } ];
+    const expectedDoc = { _id: 'a' };
+    const expected = [ { doc: expectedDoc } ];
     const given = '22222';
     const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: expected });
     utils.getRegistrations({ db: db, id: given }, (err, actual) => {
         test.equals(err, null);
-        test.deepEqual(actual, expected);
+        test.deepEqual(actual, [ expectedDoc ]);
         test.equals(view.callCount, 1);
         test.equals(view.args[0][0], 'medic');
         test.equals(view.args[0][1], 'registered_patients');
@@ -571,12 +572,14 @@ exports['getRegistrations queries by id if given'] = test => {
 };
 
 exports['getRegistrations queries by ids if given'] = test => {
-    const expected = [ { id: 'a' }, { id: 'b' } ];
+    const expectedDoc1 = { id: 'a' };
+    const expectedDoc2 = { id: 'b' };
+    const expected = [ { doc: expectedDoc1 } , { doc: expectedDoc2 } ];
     const given = ['11111', '22222'];
     const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: expected });
     utils.getRegistrations({ db: db, ids: given }, (err, actual) => {
         test.equals(err, null);
-        test.deepEqual(actual, expected);
+        test.deepEqual(actual, [expectedDoc1, expectedDoc2 ]);
         test.equals(view.callCount, 1);
         test.equals(view.args[0][0], 'medic');
         test.equals(view.args[0][1], 'registered_patients');

--- a/transitions/accept_patient_reports.js
+++ b/transitions/accept_patient_reports.js
@@ -167,11 +167,10 @@ module.exports = {
             db: db,
             id: doc.fields && doc.fields.patient_id
         },
-        function(err, registrationRows) {
+        function(err, registrations) {
             if (err) {
                 return callback(err);
             }
-            const registrations = registrationRows.map(row => row.doc);
 
             if (patientContact) {
                 addMessagesToDoc(doc, config, registrations, patientContact);

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -337,8 +337,8 @@ module.exports = {
     }
     async.parallel({
       registrations: _.partial(getRegistrations, db, patientId),
-      person: _.partial(utils.getPatientContact, db, patientId)
-    }, (err, {registrations, person}) => {
+      patient: _.partial(utils.getPatientContact, db, patientId)
+    }, (err, {registrations, patient}) => {
       if (err) {
         return callback(err);
       }
@@ -351,7 +351,7 @@ module.exports = {
             message: messages.getMessage(msg, locale),
             templateContext: extra,
             registrations: registrations,
-            person: person
+            patient: patient
           });
         }
       });
@@ -363,15 +363,15 @@ module.exports = {
 
     async.parallel({
       registrations: _.partial(getRegistrations, options.db, patientId),
-      person: _.partial(utils.getPatientContact, options.db, patientId)
-    }, (err, {registrations, person}) => {
+      patient: _.partial(utils.getPatientContact, options.db, patientId)
+    }, (err, {registrations, patient}) => {
       if (err) {
         return callback(err);
       }
       options.params.forEach(scheduleName => {
         const schedule = schedules.getScheduleConfig(scheduleName);
         const assigned = schedules.assignSchedule(
-          options.doc, schedule, registrations, person);
+          options.doc, schedule, registrations, patient);
         if (!assigned) {
           logger.error('Failed to add schedule please verify settings.');
         }

--- a/transitions/update_notifications.js
+++ b/transitions/update_notifications.js
@@ -49,7 +49,7 @@ module.exports = {
             messages.addError(doc, err_msg.replace('%s', event_type));
         }
     },
-    _addMsg: function(event_type, config, doc, registrations) {
+    _addMsg: function(event_type, config, doc, registrations, patient) {
         var locale = utils.getLocale(doc),
             evConf = _.findWhere(config.messages, {
                 event_type: event_type
@@ -60,7 +60,8 @@ module.exports = {
                 doc: doc,
                 message: msg,
                 phone: messages.getRecipientPhone(doc, msg.recipient),
-                registrations: registrations
+                registrations: registrations,
+                patient: patient
             });
         } else {
             module.exports._addErr(event_type, config, doc);
@@ -127,24 +128,26 @@ module.exports = {
                 return callback(null, true);
             }
 
-            utils.getRegistrations({
-                db: db,
-                id: patient_id
-            }, function(err, registrations) {
+            async.parallel({
+              registrations: _.partial(utils.getRegistrations, {db: db, id: patient_id}),
+              patient: _.partial(utils.getPatientContact, db, patient_id)
+            }, (err, {registrations, patient}) => {
 
                 if (err) {
-                    callback(err);
-                } else if (registrations.length) {
+                    return callback(err);
+                }
+
+                if (registrations.length) {
                     if (eventType.mute) {
                         if (config.confirm_deactivation) {
                             self._addErr('confirm_deactivation', config, doc);
-                            self._addMsg('confirm_deactivation', config, doc, registrations);
+                            self._addMsg('confirm_deactivation', config, doc, registrations, patient);
                             return callback(null, true);
                         } else {
-                            self._addMsg('on_mute', config, doc, registrations);
+                            self._addMsg('on_mute', config, doc, registrations, patient);
                         }
                     } else {
-                        self._addMsg('on_unmute', config, doc, registrations);
+                        self._addMsg('on_unmute', config, doc, registrations, patient);
                     }
                     async.each(registrations, function(registration, callback) {
                         self.modifyRegistration({
@@ -161,7 +164,7 @@ module.exports = {
                     });
                 } else {
                     self._addErr('patient_not_found', config, doc);
-                    self._addMsg('patient_not_found', config, doc, registrations);
+                    self._addMsg('patient_not_found', config, doc);
                     callback(null, true);
                 }
             });

--- a/transitions/update_notifications.js
+++ b/transitions/update_notifications.js
@@ -150,7 +150,7 @@ module.exports = {
                         self.modifyRegistration({
                             audit: audit,
                             mute: eventType.mute,
-                            registration: registration.doc
+                            registration: registration
                         }, callback);
                     }, function(err) {
                         if (err) {


### PR DESCRIPTION
**Please don't squash**

# Description

Removes support for `{{person.name}}` in favour of just allowing `{{patient_name}}`, and made sure the patient is passed in correctly to populate that value.

See individual commit notes for specifics. 

medic/medic-webapp#3838

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
