### PR TITLE
Store sentinel meta-data in a _local document

### DIFF
--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -195,7 +195,7 @@ exports['loadTransitions does not load system transistions that have been explic
 
 exports['attach handles missing meta data doc'] = test => {
   const get = sinon.stub(db.medic, 'get');
-  get.withArgs('sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
+  get.withArgs('_local/sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
   const fetchHydratedDoc = sinon.stub(lineage, 'fetchHydratedDoc').returns(Promise.resolve({ type: 'data_record' }));
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
@@ -212,7 +212,7 @@ exports['attach handles missing meta data doc'] = test => {
     test.equal(applyTransitions.args[0][0].change.id, 'abc');
     test.equal(applyTransitions.args[0][0].change.seq, 55);
     test.equal(insert.callCount, 1);
-    test.equal(insert.args[0][0]._id, 'sentinel-meta-data');
+    test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
     test.equal(insert.args[0][0].processed_seq, 55);
     test.done();
   };
@@ -229,7 +229,7 @@ exports['attach handles missing meta data doc'] = test => {
 
 exports['attach handles existing meta data doc'] = test => {
   const get = sinon.stub(db.medic, 'get');
-  get.withArgs('sentinel-meta-data').callsArgWith(1, null, { _id: 'sentinel-meta-data', processed_seq: 22 });
+  get.withArgs('_local/sentinel-meta-data').callsArgWith(1, null, { _id: '_local/sentinel-meta-data', processed_seq: 22 });
   const fetchHydratedDoc = sinon.stub(lineage, 'fetchHydratedDoc').returns(Promise.resolve({ type: 'data_record' }));
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
@@ -246,7 +246,7 @@ exports['attach handles existing meta data doc'] = test => {
     test.equal(applyTransitions.args[0][0].change.id, 'abc');
     test.equal(applyTransitions.args[0][0].change.seq, 55);
     test.equal(insert.callCount, 1);
-    test.equal(insert.args[0][0]._id, 'sentinel-meta-data');
+    test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
     test.equal(insert.args[0][0].processed_seq, 55);
     test.done();
   };

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -68,7 +68,7 @@ const SYSTEM_TRANSITIONS = [
   }
 })();
 
-const METADATA_DOCUMENT = 'sentinel-meta-data';
+const METADATA_DOCUMENT = '_local/sentinel-meta-data';
 
 let processed = 0;
 


### PR DESCRIPTION
This document stores sequence numbers, and so is only relevant on the
specific instance it was created on. Replicating it to another instance
will cause sentinel to behave incorrectly.

medic/medic-webapp#3860

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
