### PR TITLE
Check params is an array for schedule triggers

### DIFF
--- a/test/unit/registration.js
+++ b/test/unit/registration.js
@@ -579,6 +579,63 @@ exports['trigger param configuration supports direct JSON'] = test => {
   });
 };
 
+exports['trigger param configuration fails with no parameters'] = test => {
+  const eventConfig = [ {
+    form: 'R',
+    events: [ {
+      name: 'on_create',
+      trigger: 'assign_schedule',
+      params: ''
+    } ]
+  } ];
+
+  sinon.stub(config, 'get').returns(eventConfig);
+  try {
+    transition.init();
+    test.done(new Error('Expected validation error'));
+  } catch(e) {
+    test.ok(e instanceof Error);
+    test.equals(e.message, 'Configuration error. Expecting params to be defined as the name of the schedule(s) for R.assign_schedule');
+    test.done();
+  }
+};
+
+exports['trigger param configuration fails with object parameters'] = test => {
+  const eventConfig = [ {
+    form: 'R',
+    events: [ {
+      name: 'on_create',
+      trigger: 'assign_schedule',
+      params: '{ "name": "hello" }'
+    } ]
+  } ];
+
+  sinon.stub(config, 'get').returns(eventConfig);
+  try {
+    transition.init();
+    test.done(new Error('Expected validation error'));
+  } catch(e) {
+    test.ok(e instanceof Error);
+    test.equals(e.message, 'Configuration error. Expecting params to be a string, comma separated list, or an array for R.assign_schedule: \'{ "name": "hello" }\'');
+    test.done();
+  }
+};
+
+exports['trigger param configuration succeeds with array parameters'] = test => {
+  const eventConfig = [ {
+    form: 'R',
+    events: [ {
+      name: 'on_create',
+      trigger: 'assign_schedule',
+      params: 'a,b'
+    } ]
+  } ];
+
+  sinon.stub(config, 'get').returns(eventConfig);
+  transition.init();
+  test.done();
+};
+
 exports['trigger param configuration parse failure for invalid JSON propagates to the callbacks'] = test => {
   const eventConfig = [ {
     form: 'R',
@@ -595,7 +652,7 @@ exports['trigger param configuration parse failure for invalid JSON propagates t
     test.done(new Error('Expected validation error'));
   } catch(e) {
     test.ok(e instanceof Error);
-    test.equals(e.message, 'Configuration error. Unable to parse params for R.testparamparsing: {"foo": "bar". Error: SyntaxError: Unexpected end of JSON input');
+    test.equals(e.message, 'Configuration error. Unable to parse params for R.testparamparsing: \'{"foo": "bar"\'. Error: SyntaxError: Unexpected end of JSON input');
     test.done();
   }
 };

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -88,11 +88,19 @@ module.exports = {
           try {
             params = parseParams(event.params);
           } catch(e) {
-            throw new Error(`Configuration error. Unable to parse params for ${config.form}.${event.trigger}: ${event.params}. Error: ${e}`);
+            throw new Error(`Configuration error. Unable to parse params for ${config.form}.${event.trigger}: '${event.params}'. Error: ${e}`);
           }
           if (event.trigger === 'add_patient' &&
               params.patient_id_field === 'patient_id') {
             throw new Error('Configuration error. patient_id_field cannot be set to patient_id');
+          }
+          if (event.trigger === 'assign_schedule' || event.trigger === 'clear_schedule') {
+            if (!event.params) {
+              throw new Error(`Configuration error. Expecting params to be defined as the name of the schedule(s) for ${config.form}.${event.trigger}`);
+            }
+            if (!_.isArray(params)) {
+              throw new Error(`Configuration error. Expecting params to be a string, comma separated list, or an array for ${config.form}.${event.trigger}: '${event.params}'`);
+            }
           }
         });
       }
@@ -308,15 +316,9 @@ module.exports = {
       cb();
     },
     assign_schedule: (options, cb) => {
-      if (!options.params) {
-        return cb('Please specify schedule name in settings.');
-      }
       module.exports.assignSchedule(options, cb);
     },
     clear_schedule: (options, cb) => {
-      if (!options.params) {
-        return cb('Please specify at least one schedule name in settings.');
-      }
       // Registration forms that clear schedules do so fully
       // silence_type will be split again later, so join them back
       options.report = {


### PR DESCRIPTION
# Description

The two schedule triggers rely on params being defined as an array.
This change checks the configuration up front rather than crashing
when processing a report.

medic/medic-webapp#3843

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
