### PR TITLE
Only include reports that haven't been counted before

### DIFF
--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -332,7 +332,7 @@ exports['message only contains newReports'] = test => {
         {
           type: 'alert',
           alert_name: alert.name,
-          countedReports: []
+          counted_reports: ['docB']
         }
       ]
     },
@@ -347,7 +347,7 @@ exports['message only contains newReports'] = test => {
         {
           type: 'alert',
           alert_name: alert.name,
-          countedReports: []
+          counted_reports: ['docB']
         }
       ]
     }

--- a/transitions/multi_report_alerts.js
+++ b/transitions/multi_report_alerts.js
@@ -45,11 +45,6 @@ const countReports = (reports, latestReport, script) => {
   });
 };
 
-/** Has this report already been SMSed about for this alert? */
-const isReportAlreadyMessaged = (report, alertName) => {
-  return report.tasks && report.tasks.filter(task => task.alert_name === alertName).length;
-};
-
 const generateMessages = (alert, phones, latestReport, countedReportsIds, newReports) => {
   let isLatestReportChanged = false;
   phones.forEach((phone) => {
@@ -94,8 +89,7 @@ const getPhones = (recipients, reports) => {
     const phonesForReport = getPhonesOneReport(recipients, report);
     phones = phones.concat(phonesForReport);
   });
-  phones = _.uniq(phones);
-  return phones;
+  return _.uniq(phones);
 };
 
 const getPhonesOneReport = (recipients, report) => {
@@ -197,19 +191,21 @@ const getCountedReportsAndPhones = (alert, latestReport) => {
 
     if (!countReports([latestReport], latestReport, script).length) {
       // The latest_report didn't pass the is_report_counted function, abort the transition.
-      return resolve({ countedReportsIds: [], newReports: [], phones: [] });
+      return resolve({
+        countedReportsIds: [],
+        newReports: [],
+        phones: []
+      });
     }
 
-    let countedReportsIds = [ latestReport._id ];
-    let newReports = [ latestReport ];
-    let phones = getPhonesOneReport(alert.recipients, latestReport);
+    let countedReports = [ latestReport ];
+    let oldReportIds = [ ];
     async.doWhilst(
       callback => {
         getCountedReportsAndPhonesBatch(script, latestReport, alert, skip)
           .then(output => {
-            countedReportsIds = countedReportsIds.concat(output.countedReportsIds);
-            newReports = newReports.concat(output.newReports);
-            phones = phones.concat(output.phones);
+            countedReports = countedReports.concat(output.countedReports);
+            oldReportIds = oldReportIds.concat(output.oldReportIds);
             callback(null, output.numFetched);
           })
           .catch(callback);
@@ -222,26 +218,37 @@ const getCountedReportsAndPhones = (alert, latestReport) => {
         if (err) {
           return reject(err);
         }
-        resolve({ countedReportsIds: countedReportsIds, newReports: newReports, phones: _.uniq(phones) });
+        const countedReportsIds = countedReports.map(report => report._id);
+        const newReports = countedReports.filter(report => !oldReportIds.includes(report._id));
+        const phones = getPhones(alert.recipients, newReports);
+        resolve({
+          countedReportsIds: countedReportsIds,
+          newReports: newReports,
+          phones: phones
+        });
       }
     );
   });
 };
 
 /**
- * Returns Promise({ numFetched, countedReportsIds, newReports, phones }) for the db batch with skip value.
+ * Returns Promise({ numFetched, countedReports, oldReportIds }) for the db batch with skip value.
  */
 const getCountedReportsAndPhonesBatch = (script, latestReport, alert, skip) => {
   const options = { skip: skip, limit: BATCH_SIZE };
   return fetchReports(latestReport.reported_date - 1, alert.time_window_in_days, alert.forms, options)
     .then(fetched => {
       const countedReports = countReports(fetched, latestReport, script);
-      const newReports = countedReports.filter(report => !isReportAlreadyMessaged(report, alert.name));
+      const oldReportIds = _.flatten(countedReports.map(report => {
+        if (report.tasks) {
+          const tasks = report.tasks.filter(task => task.alert_name === alert.name);
+          return tasks.map(task => task.counted_reports);
+        }
+      }));
       return {
         numFetched: fetched.length,
-        countedReportsIds: countedReports.map(report => report._id),
-        newReports: newReports,
-        phones: getPhones(alert.recipients, newReports)
+        countedReports: countedReports,
+        oldReportIds: oldReportIds
       };
     });
 };


### PR DESCRIPTION
# Description

When the multi_report_alerts transition fires it messages all the
configured recipients of the reports that haven't been messaged
already. The message task is only stored on the latest report.

This patch modifies the algorithm for determining which reports
have been processed by using the counted_reports array on the
message task, rather than incorrectly assuming all reports have a
message task.

medic/medic-webapp#3875

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
