### PR TITLE
Just use promises

### DIFF
--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -529,9 +529,12 @@ exports['getCountedReportsAndPhones batches properly'] = test => {
   const firstBatch = [...Array(100).keys()].map(report);
   const secondBatch = [...Array(50).keys()].map(report);
 
-  const stub = sinon.stub(utils, 'getReportsWithinTimeWindow');
-  stub.onCall(0).returns(Promise.resolve(firstBatch));
-  stub.onCall(1).returns(Promise.resolve(secondBatch));
+  const hdStub = sinon.stub(lineage, 'hydrateDocs');
+  hdStub.onCall(0).returns(Promise.resolve(firstBatch));
+  hdStub.onCall(1).returns(Promise.resolve(secondBatch));
+  const grwtwStub = sinon.stub(utils, 'getReportsWithinTimeWindow');
+  grwtwStub.onCall(0).returns(Promise.resolve(firstBatch));
+  grwtwStub.onCall(1).returns(Promise.resolve(secondBatch));
 
   transition._getCountedReportsAndPhones(alert, doc)
     .then(({countedReportsIds, newReports}) => {

--- a/test/unit/transitions/multi_report_alerts.js
+++ b/test/unit/transitions/multi_report_alerts.js
@@ -522,3 +522,22 @@ exports['latest report has to go through is_report_counted function'] = test => 
     test.done();
   });
 };
+
+exports['getCountedReportsAndPhones batches properly'] = test => {
+  const report = () => ({ _id: 'docA', form: 'A', contact: { _id: 'contactA' } });
+
+  const firstBatch = [...Array(100).keys()].map(report);
+  const secondBatch = [...Array(50).keys()].map(report);
+
+  const stub = sinon.stub(utils, 'getReportsWithinTimeWindow');
+  stub.onCall(0).returns(Promise.resolve(firstBatch));
+  stub.onCall(1).returns(Promise.resolve(secondBatch));
+
+  transition._getCountedReportsAndPhones(alert, doc)
+    .then(({countedReportsIds, newReports}) => {
+      // Two batches above, plus the doc passed in
+      test.equal(countedReportsIds.length, 151);
+      test.equal(newReports.length, 151);
+      test.done();
+    });
+};


### PR DESCRIPTION
This batching code wrapped a promise in a callback in a promise.

Instead, just use promises.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
