### PR TITLE
Optimise contact fetch

### DIFF
--- a/lib/lineage.js
+++ b/lib/lineage.js
@@ -69,15 +69,26 @@ const fetchHydratedDoc = id => {
         });
       }
 
-      // FIXME: We may already have some of these docs in `lineage` above
-      //        https://github.com/medic/medic-webapp/issues/3913
       const contactIds = _.uniq(lineage
         .map(doc => doc && doc.contact && doc.contact._id)
         .filter(id => !!id));
 
-      return resolve(fetchDocs(contactIds)
-        .then(contacts => {
-          fillContactsInDocs(lineage, contacts);
+      // Only fetch docs that are new to us
+      const lineageContacts = [],
+            contactsToFetch = [];
+      contactIds.forEach(id => {
+        const contact = lineage.find(d => d._id === id);
+        if (contact) {
+          lineageContacts.push(contact);
+        } else {
+          contactsToFetch.push(id);
+        }
+      });
+
+      return resolve(fetchDocs(contactsToFetch)
+        .then(fetchedContacts => {
+          const allContacts = lineageContacts.concat(fetchedContacts);
+          fillContactsInDocs(lineage, allContacts);
           const doc = lineage.shift();
           buildHydratedDoc(doc, lineage);
           return doc;


### PR DESCRIPTION
No longer fetch contacts that we already have by virtue of them being
in the lineage already.

This most frequently applies to the situation where a CHW is the
contact for its parent area: in this instance we don't need to fetch
the CHW again.

medic/medic-webapp#3913

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
