### PR TITLE
Delete server side info and meta docs

### DIFF
--- a/db.js
+++ b/db.js
@@ -34,6 +34,7 @@ if (couchUrl) {
 } else if (process.env.TEST_ENV) {
     // Running tests only
     module.exports = {
+        use: function() {},
         fti: function() {},
         medic: {
             view: function() {},

--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -276,3 +276,98 @@ transitions.availableTransitions().forEach(name => {
     };
   });
 });
+
+exports['deleteInfo doc handles missing info doc'] = test => {
+  const given = { id: 'abc' };
+  sinon.stub(db.medic, 'get').callsArgWith(1, { statusCode: 404 });
+  transitions._deleteInfoDoc(given, err => {
+    test.equal(err, undefined);
+    test.done();
+  });
+};
+
+exports['deleteInfoDoc deletes info doc'] = test => {
+  const given = { id: 'abc' };
+  const get = sinon.stub(db.medic, 'get').callsArgWith(1, null, { _id: 'abc', _rev: '123' });
+  const insert = sinon.stub(db.medic, 'insert').callsArg(1);
+  transitions._deleteInfoDoc(given, err => {
+    test.equal(err, undefined);
+    test.equal(get.callCount, 1);
+    test.equal(get.args[0][0], 'abc-info');
+    test.equal(insert.callCount, 1);
+    test.equal(insert.args[0][0]._deleted, true);
+    test.done();
+  });
+};
+
+exports['deleteReadDocs handles missing meta db'] = test => {
+  const given = { id: 'abc' };
+  const metaDb = { info: function() {} };
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, {
+    rows: [ { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } } ]
+  });
+  sinon.stub(db, 'use').returns(metaDb);
+  sinon.stub(metaDb, 'info').callsArgWith(0, { statusCode: 404 });
+  transitions._deleteReadDocs(given, err => {
+    test.equal(err, undefined);
+    test.done();
+  });
+};
+
+exports['deleteReadDocs handles missing read doc'] = test => {
+  const given = { id: 'abc' };
+  const metaDb = {
+    info: function() {},
+    fetch: function() {}
+  };
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+    { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } }
+  ] });
+  sinon.stub(db, 'use').returns(metaDb);
+  sinon.stub(metaDb, 'info').callsArg(0);
+  sinon.stub(metaDb, 'fetch').callsArgWith(1, null, { rows: [ { error: 'notfound' } ] });
+  transitions._deleteReadDocs(given, err => {
+    test.equal(err, undefined);
+    test.done();
+  });
+};
+
+exports['deleteReadDocs deletes read doc for all admins'] = test => {
+  const given = { id: 'abc' };
+  const metaDb = {
+    info: function() {},
+    fetch: function() {},
+    insert: function() {}
+  };
+  const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+    { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } },
+    { id: 'org.couchdb.user:jim', doc: { roles: [ 'user', 'national_admin' ] } },
+    { id: 'org.couchdb.user:nobody', doc: { roles: [ 'user', 'district_admin' ] } }
+  ] });
+  const use = sinon.stub(db, 'use').returns(metaDb);
+  const info = sinon.stub(metaDb, 'info').callsArg(0);
+  const fetch = sinon.stub(metaDb, 'fetch').callsArgWith(1, null, { rows: [
+    { error: 'notfound' },
+    { doc: { id: 'xyz' } }
+  ] });
+  const insert = sinon.stub(metaDb, 'insert').callsArg(1);
+  transitions._deleteReadDocs(given, err => {
+    test.equal(err, undefined);
+    test.equal(view.callCount, 1);
+    test.equal(use.callCount, 2);
+    test.equal(use.args[0][0], 'medic-user-gareth-meta');
+    test.equal(use.args[1][0], 'medic-user-jim-meta');
+    test.equal(info.callCount, 2);
+    test.equal(fetch.callCount, 2);
+    test.equal(fetch.args[0][0].keys.length, 2);
+    test.equal(fetch.args[0][0].keys[0], 'read:report:abc');
+    test.equal(fetch.args[0][0].keys[1], 'read:message:abc');
+    test.equal(fetch.args[1][0].keys.length, 2);
+    test.equal(fetch.args[1][0].keys[0], 'read:report:abc');
+    test.equal(fetch.args[1][0].keys[1], 'read:message:abc');
+    test.equal(insert.callCount, 2);
+    test.equal(insert.args[0][0]._deleted, true);
+    test.equal(insert.args[1][0]._deleted, true);
+    test.done();
+  });
+};

--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -304,7 +304,7 @@ exports['deleteReadDocs handles missing meta db'] = test => {
   const given = { id: 'abc' };
   const metaDb = { info: function() {} };
   sinon.stub(db.medic, 'view').callsArgWith(3, null, {
-    rows: [ { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } } ]
+    rows: [ { id: 'org.couchdb.user:gareth' } ]
   });
   sinon.stub(db, 'use').returns(metaDb);
   sinon.stub(metaDb, 'info').callsArgWith(0, { statusCode: 404 });
@@ -321,7 +321,7 @@ exports['deleteReadDocs handles missing read doc'] = test => {
     fetch: function() {}
   };
   sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } }
+    { id: 'org.couchdb.user:gareth' }
   ] });
   sinon.stub(db, 'use').returns(metaDb);
   sinon.stub(metaDb, 'info').callsArg(0);
@@ -340,9 +340,8 @@ exports['deleteReadDocs deletes read doc for all admins'] = test => {
     insert: function() {}
   };
   const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
-    { id: 'org.couchdb.user:gareth', doc: { roles: [ '_admin' ] } },
-    { id: 'org.couchdb.user:jim', doc: { roles: [ 'user', 'national_admin' ] } },
-    { id: 'org.couchdb.user:nobody', doc: { roles: [ 'user', 'district_admin' ] } }
+    { id: 'org.couchdb.user:gareth' },
+    { id: 'org.couchdb.user:jim' }
   ] });
   const use = sinon.stub(db, 'use').returns(metaDb);
   const info = sinon.stub(metaDb, 'info').callsArg(0);

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -79,13 +79,27 @@ const processChange = (change, callback) => {
   if (!change) {
     return callback();
   }
+  logger.debug(`change event on doc ${change.id} seq ${change.seq}`);
+  if (processed > 0 && (processed % PROGRESS_REPORT_INTERVAL) === 0) {
+    logger.info(`transitions: ${processed} items processed (since sentinel started)`);
+  }
+  if (change.deleted) {
+    // don't run transitions on deleted docs, but do clean up
+    async.parallel([
+      async.apply(deleteInfoDoc, change),
+      async.apply(deleteReadDocs, change)
+    ], err => {
+      if (err) {
+        logger.error('Error cleaning up deleted doc', err);
+      }
+      processed++;
+      updateMetaData(change.seq, callback);
+    });
+    return;
+  }
   lineage.fetchHydratedDoc(change.id)
     .then(doc => {
-      if (processed > 0 && (processed % PROGRESS_REPORT_INTERVAL) === 0) {
-        logger.info(`transitions: ${processed} items processed (since sentinel started)`);
-      }
       change.doc = doc;
-      logger.debug(`change event on doc ${change.id} seq ${change.seq}`);
       const audit = require('couchdb-audit')
             .withNano(db, db.settings.db, db.settings.auditDb, db.settings.ddoc, db.settings.username);
       module.exports.applyTransitions({
@@ -101,6 +115,83 @@ const processChange = (change, callback) => {
       logger.error(`transitions: fetch failed for ${change.id} (${err})`);
       return callback();
     });
+};
+
+const deleteInfoDoc = (change, callback) => {
+  db.medic.get(`${change.id}-info`, (err, doc) => {
+    if (err) {
+      if (err.statusCode === 404) {
+        // don't worry about deleting a non-existant doc
+        return callback();
+      }
+      return callback(err);
+    }
+    doc._deleted = true;
+    db.medic.insert(doc, callback);
+  });
+};
+
+const getAdminNames = callback => {
+  const options = { key: [ 'user-settings' ], include_docs: true };
+  db.medic.view('medic-client', 'doc_by_type', options, (err, results) => {
+    if (err) {
+      return callback(err);
+    }
+    const admins = results.rows
+      .filter(row => {
+        return row.doc.roles &&
+               (row.doc.roles.includes('_admin') ||
+               row.doc.roles.includes('national_admin'));
+      })
+      .map(row => {
+        const parts = row.id.split(':');
+        return parts.length > 1 && parts[1];
+      })
+      .filter(name => !!name);
+    callback(null, admins);
+  });
+};
+
+const deleteReadDocs = (change, callback) => {
+
+  // we don't know if the deleted doc was a report or a message so
+  // attempt to delete both
+  const possibleReadDocIds = [ 'report', 'message' ]
+    .map(type => `read:${type}:${change.id}`);
+
+  getAdminNames((err, admins) => {
+    if (err) {
+      return callback(err);
+    }
+
+    async.each(
+      admins,
+      (admin, callback) => {
+        const metaDb = db.use(`medic-user-${admin}-meta`);
+        metaDb.info(err => {
+          if (err) {
+            if (err.statusCode === 404) {
+              // no meta data db exists for this user - ignore
+              return callback();
+            }
+            return callback(err);
+          }
+          metaDb.fetch({ keys: possibleReadDocIds }, (err, results) => {
+            if (err) {
+              return callback(err);
+            }
+            const row = results.rows.find(row => !!row.doc);
+            if (!row) {
+              return callback();
+            }
+            row.doc._deleted = true;
+            metaDb.insert(row.doc, callback);
+          });
+        });
+      },
+      callback
+    );
+  });
 };
 
 /*
@@ -392,10 +483,7 @@ const attach = () => {
     });
     changesFeed.on('change', change => {
       // skip uninteresting documents
-      if (change.deleted ||
-          change.id.match(/^_design\//) ||
-          change.id === METADATA_DOCUMENT) {
-
+      if (change.id.match(/^_design\//) || change.id === METADATA_DOCUMENT) {
         return;
       }
       changeQueue.push(change);
@@ -416,6 +504,8 @@ module.exports = {
   _changeQueue: changeQueue,
   _attach: attach,
   _detach: detach,
+  _deleteInfoDoc: deleteInfoDoc,
+  _deleteReadDocs: deleteReadDocs,
   availableTransitions: availableTransitions,
   loadTransitions: loadTransitions,
   canRun: canRun,

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -132,17 +132,11 @@ const deleteInfoDoc = (change, callback) => {
 };
 
 const getAdminNames = callback => {
-  const options = { key: [ 'user-settings' ], include_docs: true };
-  db.medic.view('medic-client', 'doc_by_type', options, (err, results) => {
+  db.medic.view('medic', 'online_user_settings_by_id', {}, (err, results) => {
     if (err) {
       return callback(err);
     }
     const admins = results.rows
-      .filter(row => {
-        return row.doc.roles &&
-               (row.doc.roles.includes('_admin') ||
-               row.doc.roles.includes('national_admin'));
-      })
       .map(row => {
         const parts = row.id.split(':');
         return parts.length > 1 && parts[1];
@@ -180,6 +174,7 @@ const deleteReadDocs = (change, callback) => {
             if (err) {
               return callback(err);
             }
+            // find which of the possible ids was the right one
             const row = results.rows.find(row => !!row.doc);
             if (!row) {
               return callback();


### PR DESCRIPTION
# Description

When a deletion is detected remove the associated meta doc and all
associated read docs in admin meta dbs. The non-admin read docs
will be deleted client side to avoid sentinel having to delete docs
from potentially thousands of databases.

medic/medic-webapp#3944

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
