### PR TITLE
Fix sentinel fti integration

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,7 +1,5 @@
 var nano = require('nano'),
-	url = require('url'),
-    path = require('path'),
-    request = require('request');
+	url = require('url');
 
 var couchUrl = process.env.COUCH_URL;
 if (couchUrl) {
@@ -9,7 +7,6 @@ if (couchUrl) {
     couchUrl = couchUrl.replace(/\/$/, '');
     var parsedUrl = url.parse(couchUrl);
     var baseUrl = couchUrl.substring(0, couchUrl.indexOf('/', 10));
-    var luceneUrl = baseUrl.replace('5984', '5985');
 
     module.exports = nano(baseUrl);
     module.exports.medic = nano(couchUrl);
@@ -29,46 +26,10 @@ if (couchUrl) {
         module.exports.settings.username = parsedUrl.auth.substring(0, index);
         module.exports.settings.password = parsedUrl.auth.substring(index + 1);
     }
-
-    module.exports.fti = function(index, data, cb) {
-        var uri = path.join('local', module.exports.settings.db, '_design',
-                            module.exports.settings.ddoc, index);
-        var url = luceneUrl + '/' + uri;
-
-        if (data.q && !data.limit) {
-            data.limit = 1000;
-        }
-        var opts = { url: url };
-        if (data.q) {
-            opts.method = 'post';
-            opts.form = data;
-        } else {
-            opts.qs = data;
-        }
-
-        request(opts, function(err, response, result) {
-            if (err) {
-                // the request itself failed
-                console.error(err);
-                return cb(new Error('Error when making lucene request'));
-            }
-            try {
-                result = JSON.parse(result);
-            } catch (e) {
-                return cb(e);
-            }
-            if (data.q && !result.rows) {
-                // the query failed for some reason
-                return cb(result);
-            }
-            cb(null, result);
-        });
-    };
 } else if (process.env.TEST_ENV) {
     // Running tests only
     module.exports = {
         use: function() {},
-        fti: function() {},
         medic: {
             view: function() {},
             get: function() {},

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -13,11 +13,11 @@ var _parseDuration = function(duration) {
 };
 
 const _getIntersection = responses => {
-    let rows = responses.pop().rows;
+    let ids = responses.pop().rows.map(row => row.id);
     responses.forEach(response => {
-        rows = rows.filter(row => _.findWhere(response.rows, { id: row.id }));
+        ids = ids.filter(id => _.findWhere(response.rows, { id: id }));
     });
-    return _.pluck(rows, 'doc');
+    return ids;
 };
 
 const _executeExistsRequest = (options, callback) => {
@@ -37,8 +37,6 @@ const _exists = (doc, fields, options, callback) => {
     const requestOptions = fields.map(field => {
         return { key: [ `${field}:${doc[field]}` ] };
     });
-    // include docs on the first request only to save fetching the same doc twice
-    requestOptions[0].include_docs = true;
     if (options.additionalFilter) {
         requestOptions.push({ key: [ options.additionalFilter ] });
     }
@@ -46,21 +44,30 @@ const _exists = (doc, fields, options, callback) => {
         if (err) {
             return callback(err);
         }
-        const docs = _getIntersection(responses)
-            .filter(match => {
-                return match._id !== doc._id && // not the received doc
-                    (!match.errors || match.errors.length === 0); // no errors
-            });
-        if (!docs.length) {
+        const ids = _getIntersection(responses)
+            .filter(id => id !== doc._id);
+        if (!ids.length) {
             return callback(null, false);
         }
-        if (!options.startDate) {
-            return callback(null, true);
-        }
-        // the views all respond with the reported_date as the value
-        // and in ascending order so check the last value in the intersection
-        const latestReportedDate = docs[docs.length - 1].reported_date;
-        callback(null, latestReportedDate >= options.startDate);
+        db.medic.fetch({ keys: ids }, (err, result) => {
+            if (err) {
+                return callback(err);
+            }
+            // filter out docs with errors
+            const rows = result.rows.filter(row => {
+                return (!row.doc.errors || row.doc.errors.length === 0);
+            });
+            if (!rows.length) {
+                return callback(null, false);
+            }
+            if (!options.startDate) {
+                return callback(null, true);
+            }
+            // the views all respond with the reported_date as the value
+            // and in ascending order so check the last value in the intersection
+            const latestReportedDate = rows[rows.length - 1].doc.reported_date;
+            callback(null, latestReportedDate >= options.startDate);
+        });
     });
 };
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -12,23 +12,56 @@ var _parseDuration = function(duration) {
     return moment.duration(parseInt(parts[0]), parts[1]);
 };
 
-var _exists = function(doc, query, callback) {
-    db.fti(
-        'data_records',
-        { q: query, include_docs: true },
-        function(err, result) {
-            if (err) {
-                return callback(err);
-            }
-            var found = _.some(result.rows, function(row) {
-                return row.id !== doc._id &&
-                       row.doc &&
-                       row.doc.errors &&
-                       row.doc.errors.length === 0;
-            });
-            return callback(null, found);
-        }
+const _getIntersection = responses => {
+    let rows = responses.pop().rows;
+    responses.forEach(response => {
+        rows = rows.filter(row => _.findWhere(response.rows, { id: row.id }));
+    });
+    return _.pluck(rows, 'doc');
+};
+
+const _executeExistsRequest = (options, callback) => {
+    db.medic.view(
+        'medic-client',
+        'reports_by_freetext',
+        options,
+        (err, response) => callback(err, response) // strip out unnecessary third argument
     );
+};
+
+const _exists = (doc, fields, options, callback) => {
+    options = options || {};
+    if (!fields.length) {
+        return callback(new Error('No arguments provided to "exists" validation function'));
+    }
+    const requestOptions = fields.map(field => {
+        return { key: [ `${field}:${doc[field]}` ] };
+    });
+    // include docs on the first request only to save fetching the same doc twice
+    requestOptions[0].include_docs = true;
+    if (options.additionalFilter) {
+        requestOptions.push({ key: [ options.additionalFilter ] });
+    }
+    async.map(requestOptions, _executeExistsRequest, (err, responses) => {
+        if (err) {
+            return callback(err);
+        }
+        const docs = _getIntersection(responses)
+            .filter(match => {
+                return match._id !== doc._id && // not the received doc
+                    (!match.errors || match.errors.length === 0); // no errors
+            });
+        if (!docs.length) {
+            return callback(null, false);
+        }
+        if (!options.startDate) {
+            return callback(null, true);
+        }
+        // the views all respond with the reported_date as the value
+        // and in ascending order so check the last value in the intersection
+        const latestReportedDate = docs[docs.length - 1].reported_date;
+        callback(null, latestReportedDate >= options.startDate);
+    });
 };
 
 var _formatParam = function(name, value) {
@@ -87,47 +120,29 @@ module.exports = {
          * Check if fields on a doc are unique in the db, return true if unique
          * false otherwise.
          */
-        unique: function(doc, validation, callback) {
-            var conjunctions = _.map(validation.funcArgs, function(field) {
-                return _formatParam(field, doc[field]);
-            });
-            _exists(doc, conjunctions.join(' AND '), function(err, result) {
+        unique: (doc, validation, callback) => {
+            _exists(doc, validation.funcArgs, null, (err, result) => {
                 if (err) {
                     logger.error('Error running "unique" validation', err);
                 }
                 callback(err, !result);
             });
         },
-        uniqueWithin: function(doc, validation, callback) {
-            var fields = _.clone(validation.funcArgs);
-            var duration = _parseDuration(fields.pop());
-            var conjunctions = _.map(fields, function(field) {
-                return _formatParam(field, doc[field]);
-            });
-            // lucene date range query bug
-            // fails: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            // works: "yyyy-MM-dd'T'HH:mm:ss.SSS"
-            var start = moment().subtract(duration).toISOString().replace(/Z$/,'');
-            var endOfTime = '3000-01-01T00:00:00';
-            conjunctions.push(
-                'reported_date<date>:[' +  start + ' TO ' + endOfTime + ']'
-            );
-            _exists(doc, conjunctions.join(' AND '), function(err, result) {
+        uniqueWithin: (doc, validation, callback) => {
+            const fields = _.clone(validation.funcArgs);
+            const duration = _parseDuration(fields.pop());
+            const startDate = moment().subtract(duration).valueOf();
+            _exists(doc, fields, { startDate: startDate }, (err, result) => {
                 if (err) {
                     logger.error('Error running "uniqueWithin" validation', err);
                 }
                 callback(err, !result);
             });
         },
-        exists: function(doc, validation, callback) {
-            var formName = validation.funcArgs[0];
-            var fieldName = validation.funcArgs[1];
-            var fieldValue = doc[validation.field];
-            var conjunctions = [
-                _formatParam('form', formName),
-                _formatParam(fieldName, fieldValue)
-            ];
-            _exists(doc, conjunctions.join(' AND '), function(err, result) {
+        exists: (doc, validation, callback) => {
+            const formName = validation.funcArgs[0];
+            const fieldName = validation.funcArgs[1];
+            _exists(doc, [ fieldName ], { additionalFilter: `form:${formName}` }, (err, result) => {
                 if (err) {
                     logger.error('Error running "exists" validation', err);
                 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -92,6 +92,9 @@ module.exports = {
                 return _formatParam(field, doc[field]);
             });
             _exists(doc, conjunctions.join(' AND '), function(err, result) {
+                if (err) {
+                    logger.error('Error running "unique" validation', err);
+                }
                 callback(err, !result);
             });
         },
@@ -110,6 +113,9 @@ module.exports = {
                 'reported_date<date>:[' +  start + ' TO ' + endOfTime + ']'
             );
             _exists(doc, conjunctions.join(' AND '), function(err, result) {
+                if (err) {
+                    logger.error('Error running "uniqueWithin" validation', err);
+                }
                 callback(err, !result);
             });
         },
@@ -121,7 +127,12 @@ module.exports = {
                 _formatParam('form', formName),
                 _formatParam(fieldName, fieldValue)
             ];
-            _exists(doc, conjunctions.join(' AND '), callback);
+            _exists(doc, conjunctions.join(' AND '), function(err, result) {
+                if (err) {
+                    logger.error('Error running "exists" validation', err);
+                }
+                callback(err, result);
+            });
         }
     },
     /**

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -50,9 +50,8 @@ exports['validate handles pupil regex'] = function(test) {
 };
 
 exports['pass unique validation when no doc found'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(5);
+    var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: []
     });
     var validations = [{
@@ -64,22 +63,24 @@ exports['pass unique validation when no doc found'] = function(test) {
         patient_id: '111'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'patient_id:"111"',
-            include_docs: true
-        }));
-        test.deepEqual(errors, []);
+        test.equal(view.callCount, 1);
+        test.equal(view.args[0][0], 'medic-client');
+        test.equal(view.args[0][1], 'reports_by_freetext');
+        test.deepEqual(view.args[0][2], {
+            include_docs: true,
+            key: ['patient_id:111']
+        });
+        test.equal(errors.length, 0);
         test.done();
     });
 };
 
 exports['pass unique validation when doc is the same'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(5);
+    var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'same',
-            doc: { errors: [] }
+            doc: { _id: 'same', errors: [] }
         }]
     });
     var validations = [{
@@ -91,22 +92,25 @@ exports['pass unique validation when doc is the same'] = function(test) {
         patient_id: '111'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'patient_id:"111"',
-            include_docs: true
-        }));
-        test.deepEqual(errors, []);
+        test.equal(view.callCount, 1);
+        test.equal(view.args[0][0], 'medic-client');
+        test.equal(view.args[0][1], 'reports_by_freetext');
+        test.deepEqual(view.args[0][2], {
+            include_docs: true,
+            key: ['patient_id:111']
+        });
+        test.equal(errors.length, 0);
         test.done();
     });
 };
 
 exports['pass unique validation when doc has errors'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(5);
+    var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'different',
-            doc: { errors: [{foo: 'bar'}] }
+            patient_id: '111',
+            doc: { errors: [{ foo: 'bar' }] }
         }]
     });
     var validations = [{
@@ -118,22 +122,24 @@ exports['pass unique validation when doc has errors'] = function(test) {
         patient_id: '111'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'patient_id:"111"',
-            include_docs: true
-        }));
-        test.deepEqual(errors, []);
+        test.equal(view.callCount, 1);
+        test.equal(view.args[0][0], 'medic-client');
+        test.equal(view.args[0][1], 'reports_by_freetext');
+        test.deepEqual(view.args[0][2], {
+            include_docs: true,
+            key: ['patient_id:111']
+        });
+        test.equal(errors.length, 0);
         test.done();
     });
 };
 
 exports['fail unique validation on doc with no errors'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(1);
+    sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'different',
-            doc: { errors: [] }
+            doc: { _id: 'different', errors: [] }
         }]
     });
     var validations = [{
@@ -149,10 +155,6 @@ exports['fail unique validation on doc with no errors'] = function(test) {
         xyz: '444'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'xyz:"444"',
-            include_docs: true
-        }));
         test.deepEqual(errors, [{
             code: 'invalid_xyz_unique',
             message: 'Duplicate: {{xyz}}.'
@@ -162,12 +164,11 @@ exports['fail unique validation on doc with no errors'] = function(test) {
 };
 
 exports['fail multiple field unique validation on doc with no errors'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(8);
+    var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'different',
-            doc: { errors: [] }
+            doc: { _id: 'different', errors: [] }
         }]
     });
     var validations = [{
@@ -184,10 +185,18 @@ exports['fail multiple field unique validation on doc with no errors'] = functio
         abc: 'cheese'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'xyz:"444" AND abc:"cheese"',
-            include_docs: true
-        }));
+        test.equal(view.callCount, 2);
+        test.equal(view.args[0][0], 'medic-client');
+        test.equal(view.args[0][1], 'reports_by_freetext');
+        test.deepEqual(view.args[0][2], {
+            include_docs: true,
+            key: ['xyz:444']
+        });
+        test.equal(view.args[1][0], 'medic-client');
+        test.equal(view.args[1][1], 'reports_by_freetext');
+        test.deepEqual(view.args[1][2], {
+            key: ['abc:cheese']
+        });
         test.deepEqual(errors, [{
             code: 'invalid_xyz_unique',
             message: 'Duplicate xyz {{xyz}} and abc {{abc}}.'
@@ -197,13 +206,16 @@ exports['fail multiple field unique validation on doc with no errors'] = functio
 };
 
 exports['pass uniqueWithin validation on old doc'] = function(test) {
-    test.expect(2);
+    test.expect(1);
     clock = sinon.useFakeTimers();
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'different',
-            doc: { errors: [] }
+            doc: {
+                _id: 'different',
+                errors: [],
+                reported_date: moment().subtract(3, 'weeks').valueOf()
+            }
         }]
     });
     var validations = [{
@@ -219,12 +231,37 @@ exports['pass uniqueWithin validation on old doc'] = function(test) {
         xyz: '444'
     };
     validation.validate(doc, validations, function(errors) {
-        var start = moment().subtract(2, 'weeks').toISOString().replace(/Z$/,'');
-        test.ok(fti.calledWith('data_records', {
-            q: 'xyz:"444" AND reported_date<date>:[' + start + ' TO 3000-01-01T00:00:00]',
-            include_docs: true
-        }));
+        test.equal(errors.length, 0);
+        test.done();
+    });
+};
 
+exports['fail uniqueWithin validation on new doc'] = function(test) {
+    test.expect(1);
+    clock = sinon.useFakeTimers();
+    sinon.stub(db.medic, 'view').callsArgWith(3, null, {
+        rows: [{
+            id: 'different',
+            doc: {
+                _id: 'different',
+                errors: [],
+                reported_date: moment().subtract(1, 'weeks').valueOf()
+            }
+        }]
+    });
+    var validations = [{
+        property: 'xyz',
+        rule: 'uniqueWithin("xyz","2 weeks")',
+        message: [{
+            content: 'Duplicate xyz {{xyz}}.',
+            locale: 'en'
+        }]
+    }];
+    var doc = {
+        _id: 'same',
+        xyz: '444'
+    };
+    validation.validate(doc, validations, function(errors) {
         test.deepEqual(errors, [{
             code: 'invalid_xyz_uniqueWithin',
             message: 'Duplicate xyz {{xyz}}.'
@@ -271,12 +308,11 @@ exports['formatParam use <int> query on integers'] = function(test) {
 };
 
 exports['pass exists validation when matching document'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(8);
+    var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'different',
-            doc: { errors: [] }
+            doc: { _id: 'different', errors: [] }
         }]
     });
     var validations = [{
@@ -289,24 +325,29 @@ exports['pass exists validation when matching document'] = function(test) {
     }];
     var doc = {
         _id: 'same',
-        parent_id: '444'
+        patient_id: '444'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'form:"REGISTRATION" AND patient_id:"444"',
-            include_docs: true
-        }));
-
+        test.equal(view.callCount, 2);
+        test.equal(view.args[0][0], 'medic-client');
+        test.equal(view.args[0][1], 'reports_by_freetext');
+        test.deepEqual(view.args[0][2], {
+            include_docs: true,
+            key: ['patient_id:444']
+        });
+        test.equal(view.args[1][0], 'medic-client');
+        test.equal(view.args[1][1], 'reports_by_freetext');
+        test.deepEqual(view.args[1][2], {
+            key: ['form:REGISTRATION']
+        });
         test.deepEqual(errors, []);
         test.done();
-
     });
 };
 
 exports['fail exists validation when no matching document'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(1);
+    sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: []
     });
     var validations = [{
@@ -322,11 +363,6 @@ exports['fail exists validation when no matching document'] = function(test) {
         parent_id: '444'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'form:"REGISTRATION" AND patient_id:"444"',
-            include_docs: true
-        }));
-
         test.deepEqual(errors, [{
             code: 'invalid_parent_id_exists',
             message: 'Unknown patient {{parent_id}}.'
@@ -337,12 +373,11 @@ exports['fail exists validation when no matching document'] = function(test) {
 };
 
 exports['fail exists validation when matching document is same as this'] = function(test) {
-    test.expect(2);
-    // simulate view results with doc attribute
-    var fti = sinon.stub(db, 'fti').callsArgWithAsync(2, null, {
+    test.expect(1);
+    sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         rows: [{
             id: 'same',
-            doc: { errors: [] }
+            doc: { _id: 'same', errors: [] }
         }]
     });
     var validations = [{
@@ -358,16 +393,10 @@ exports['fail exists validation when matching document is same as this'] = funct
         parent_id: '444'
     };
     validation.validate(doc, validations, function(errors) {
-        test.ok(fti.calledWith('data_records', {
-            q: 'form:"REGISTRATION" AND patient_id:"444"',
-            include_docs: true
-        }));
-
         test.deepEqual(errors, [{
             code: 'invalid_parent_id_exists',
             message: 'Unknown patient {{parent_id}}.'
         }]);
         test.done();
-
     });
 };


### PR DESCRIPTION
# Description

The `db.fti` function wasn't working due to a double slash in the
URL. It's not clear when this was broken.

Added logging so when validation functions error out the error
is logged.

Also future-proofed the `db.fti` function using the similar code
from medic-api so it works with couchdb2.

medic/medic-webapp#651

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
