### PR TITLE
Allow SMS to be sent to other people based on bool_expr

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,6 +1,7 @@
 var _ = require('underscore'),
     template = require('./template'),
     utils = require('./utils'),
+    objectPath = require('object-path'),
     logger = require('./logger');
 
 function extendedTemplateContext(doc, extras) {
@@ -184,7 +185,7 @@ module.exports = {
         } else if (recipient.indexOf('.') > -1) {
             // Or multiple layers by executing it as a statement
             try {
-                phone = utils.evalExpression({doc: doc}, 'doc.' + recipient);
+                phone = objectPath.get(doc, recipient);
             } catch (err) {
                 logger.error(`Recipient expression "${recipient}" failed on ${doc._id}`);
             }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -175,12 +175,21 @@ module.exports = {
             phone = utils.getHealthCenterPhone(doc);
         } else if (recipient === 'grandparent') {
             phone = utils.getDistrictPhone(doc);
+        } else if (doc.fields && doc.fields[recipient]) {
+            // Try to resolve a specified property/field name
+            phone = doc.fields[recipient];
+        } else if (doc[recipient]) {
+            // Or directly on the doc
+            phone = doc[recipient];
+        } else if (recipient.indexOf('.') > -1) {
+            // Or multiple layers by executing it as a statement
+            try {
+                phone = utils.evalExpression({doc: doc}, 'doc.' + recipient);
+            } catch (err) {
+                logger.error(`Recipient expression "${recipient}" failed on ${doc._id}`);
+            }
         }
 
-        if (!phone && doc.fields && doc.fields[recipient]) {
-            // try to resolve a specified property/field name
-            phone = doc.fields[recipient];
-        }
         return phone || _default || doc.from;
     },
     addMessage: addMessage,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -531,9 +531,9 @@ module.exports = {
   getPatientContact: (db, patientShortcodeId, callback) => {
     getPatient(db, patientShortcodeId, true, callback);
   },
-  isValidBooleanExpression: expr =>
+  isNonEmptyString: expr =>
     typeof expr === 'string' && expr.trim() !== '',
-  evalExpression: (context, expr) =>
+  evalExpression: (expr, context) =>
     vm.runInNewContext(expr, context),
   _isMessageFromGateway: _isMessageFromGateway
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const _ = require('underscore'),
+      vm = require('vm'),
       db = require('../db'),
       uuid = require('uuid'),
       moment = require('moment'),
@@ -530,5 +531,9 @@ module.exports = {
   getPatientContact: (db, patientShortcodeId, callback) => {
     getPatient(db, patientShortcodeId, true, callback);
   },
+  isValidBooleanExpression: expr =>
+    typeof expr === 'string' && expr.trim() !== '',
+  evalExpression: (context, expr) =>
+    vm.runInNewContext(expr, context),
   _isMessageFromGateway: _isMessageFromGateway
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5101,6 +5101,11 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-path": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "moment": "^2.19.1",
     "mustache": "^2.1.3",
     "nano": "^6.4.2",
+    "object-path": "^0.11.4",
     "underscore": "^1.8.3",
     "uuid": "^3.1.0",
     "winston": "^2.4.0"

--- a/test/functional/schedules.js
+++ b/test/functional/schedules.js
@@ -71,7 +71,6 @@ exports['registration sets up schedule'] = function(test) {
             }
         ]
     }]);
-    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
@@ -345,7 +344,6 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
             }
         ]
     }]);
-    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
     var getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, [ { fields: { patient_name: 'barry' } } ]);
     sinon.stub(schedules, 'getScheduleConfig').returns({
         name: 'group1',
@@ -373,7 +371,10 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
         from: contact.phone,
         contact: contact,
         foo: 'baz',
-        fields: { patient_id: '123' }
+        fields: { patient_id: '123' },
+        patient: {
+            _id: 'uuid'
+        }
     };
 
     transition.onMatch({

--- a/test/mocha/lib/messages.js
+++ b/test/mocha/lib/messages.js
@@ -1,0 +1,134 @@
+const should = require('chai').should();
+const sinon = require('sinon').sandbox.create();
+
+describe('messages util', () => {
+  const messages = require('../../../lib/messages');
+
+  afterEach(done => {
+    sinon.restore();
+    done();
+  });
+
+  describe('getRecipientPhone', () => {
+    it('is undefined if no doc is passed', () => {
+      should.not.exist(messages.getRecipientPhone());
+    });
+    it('is the passed default if no recipient is defined', () => {
+      messages.getRecipientPhone({}, '', 'the-default')
+        .should.equal('the-default');
+    });
+    it('is doc.from is no recipient or default is defined', () => {
+      messages.getRecipientPhone({from: 'foo'})
+        .should.equal('foo');
+    });
+    describe('recipient variations', () => {
+      const fromPhone = 'fromPhone',
+            clinicPhone = 'clinicPhone',
+            parentPhone = 'parentPhone',
+            grandparentPhone = 'grandParentPhone',
+            fieldsPhone = 'fieldsPhone',
+            inlinePhone = 'inlinePhone',
+            complexInlinePhone = 'complexInlinePhone';
+      const doc = {
+        form: 'x',
+        from: fromPhone,
+        fields: {
+          phone: fieldsPhone,
+        },
+        phone: inlinePhone,
+        contact: {
+          parent: {
+            type: 'clinic',
+            contact: {
+              phone: clinicPhone
+            },
+            parent: {
+              type: 'health_center',
+              contact: {
+                phone: parentPhone
+              },
+              parent: {
+                type: 'district_hospital',
+                contact: {
+                  phone: grandparentPhone
+                }
+              }
+            }
+          }
+        },
+        complex: { inline: { phone: complexInlinePhone }}
+      };
+
+      it('resolves reporting_unit correctly', () => {
+        messages.getRecipientPhone(doc, 'reporting_unit')
+          .should.equal(fromPhone);
+      });
+      it('resolves clinic correctly', () => {
+        messages.getRecipientPhone(doc, 'clinic')
+          .should.equal(clinicPhone);
+      });
+      it('resolves parent correctly', () => {
+        messages.getRecipientPhone(doc, 'parent')
+          .should.equal(parentPhone);
+      });
+      it('resolves grandparent correctly', () => {
+        messages.getRecipientPhone(doc, 'grandparent')
+          .should.equal(grandparentPhone);
+      });
+    });
+    it('tries to resolve the value from the fields property', () => {
+      messages.getRecipientPhone({fields: {foo: 'bar'}}, 'foo')
+        .should.equal('bar');
+    });
+    it('tries to resolve simple values directly on the doc', () => {
+      messages.getRecipientPhone({foo: 'bar'}, 'foo')
+        .should.equal('bar');
+    });
+    it('tries to resolve complex values directly on the doc', () => {
+      messages.getRecipientPhone({foo: {bar: {smang: 'baz'}}}, 'foo.bar.smang')
+        .should.equal('baz');
+    });
+    it('is the passed default if the recipient cannot be resolved', () => {
+      messages.getRecipientPhone({}, 'a-recipient', 'default')
+        .should.equal('default');
+    });
+    it('is doc.from if no default is passed and the recipient cannot be resolved', () => {
+      messages.getRecipientPhone({from: 'foo'}, 'a-recipient')
+        .should.equal('foo');
+    });
+  });
+});
+
+// exports['getRecipientPhone defaults to doc.from if no recipient'] = function(test) {
+//     var phone = '+13125551213';
+//     var doc = {
+//         form: 'x',
+//         from: phone
+//     };
+//     var result = messages.getRecipientPhone(doc);
+//     test.equals(result, phone);
+//     test.done();
+// };
+
+// exports['getRecipientPhone defaults to doc.from if no known recipient'] = function(test) {
+//     var phone = '+13125551213';
+//     var doc = {
+//         form: 'x',
+//         from: phone
+//     };
+//     var result = messages.getRecipientPhone(doc, 'greatgrandparent');
+//     test.equals(result, phone);
+//     test.done();
+// };
+
+// exports['getRecipientPhone defaults to given default'] = function(test) {
+//     var phone = '+13125551213';
+//     var doc = {
+//         form: 'x',
+//         from: '+6666666666'
+//     };
+//     var result = messages.getRecipientPhone(doc, 'greatgrandparent', phone);
+//     test.equals(result, phone);
+//     test.done();
+// };
+

--- a/test/mocha/lib/messages.js
+++ b/test/mocha/lib/messages.js
@@ -98,37 +98,3 @@ describe('messages util', () => {
     });
   });
 });
-
-// exports['getRecipientPhone defaults to doc.from if no recipient'] = function(test) {
-//     var phone = '+13125551213';
-//     var doc = {
-//         form: 'x',
-//         from: phone
-//     };
-//     var result = messages.getRecipientPhone(doc);
-//     test.equals(result, phone);
-//     test.done();
-// };
-
-// exports['getRecipientPhone defaults to doc.from if no known recipient'] = function(test) {
-//     var phone = '+13125551213';
-//     var doc = {
-//         form: 'x',
-//         from: phone
-//     };
-//     var result = messages.getRecipientPhone(doc, 'greatgrandparent');
-//     test.equals(result, phone);
-//     test.done();
-// };
-
-// exports['getRecipientPhone defaults to given default'] = function(test) {
-//     var phone = '+13125551213';
-//     var doc = {
-//         form: 'x',
-//         from: '+6666666666'
-//     };
-//     var result = messages.getRecipientPhone(doc, 'greatgrandparent', phone);
-//     test.equals(result, phone);
-//     test.done();
-// };
-

--- a/test/mocha/lib/utils.js
+++ b/test/mocha/lib/utils.js
@@ -57,24 +57,24 @@ describe('utils util', () => {
 
     utils.getDistrictPhone(doc).should.equal(phone);
   });
-  it('isValidBooleanExpression, a valid expression is a non-empty string', () => {
-    utils.isValidBooleanExpression().should.equal(false);
-    utils.isValidBooleanExpression('').should.equal(false);
-    utils.isValidBooleanExpression(123).should.equal(false);
-    utils.isValidBooleanExpression(['hello']).should.equal(false);
-    utils.isValidBooleanExpression('foo.bar').should.equal(true);
+  it('isNonEmptyString works', () => {
+    utils.isNonEmptyString().should.equal(false);
+    utils.isNonEmptyString('').should.equal(false);
+    utils.isNonEmptyString(123).should.equal(false);
+    utils.isNonEmptyString(['hello']).should.equal(false);
+    utils.isNonEmptyString('foo.bar').should.equal(true);
   });
   describe('evalExpression', () => {
     it('evals a given expression', () => {
-      utils.evalExpression({}, '(1+2+3) !== 24').should.equal(true);
-      utils.evalExpression({}, '(1+2+3) === 24').should.equal(false);
+      utils.evalExpression('(1+2+3) !== 24', {}).should.equal(true);
+      utils.evalExpression('(1+2+3) === 24', {}).should.equal(false);
     });
     it('provides the passed context to the exprssion', () => {
-      utils.evalExpression({doc: {foo: 42, bar: 24}}, 'doc.foo + doc.bar')
+      utils.evalExpression('doc.foo + doc.bar', {doc: {foo: 42, bar: 24}})
         .should.equal(66);
     });
     it('throws an exception if the expression errors', () => {
-      should.Throw(() => utils.evalExpression({}, `doc.foo.bar.smang === 'cats'`));
+      should.Throw(() => utils.evalExpression(`doc.foo.bar.smang === 'cats'`, {}));
     });
   });
 });

--- a/test/mocha/lib/utils.js
+++ b/test/mocha/lib/utils.js
@@ -1,0 +1,80 @@
+const should = require('chai').should();
+
+describe('utils util', () => {
+  const utils = require('../../../lib/utils');
+  describe('getClinicPhone', () => {
+    it('gets the phone number of the clinic', () => {
+      const phone = '123';
+      const doc = {
+        contact: {
+          parent: {
+            type: 'clinic',
+            contact: { phone: phone }
+          }
+        }
+      };
+
+      utils.getClinicPhone(doc).should.equal(phone);
+    });
+    it('gets the contact phone number if there is no clinic', () => {
+      const phone = '123';
+      const doc = {
+        contact: {
+          phone: phone
+        }
+      };
+
+      utils.getClinicPhone(doc).should.equal(phone);
+    });
+  });
+  it('getHealthCenterPhone works', () => {
+      const phone = '123';
+      const doc = {
+        contact: {
+          parent: {
+            type: 'health_center',
+            contact: {
+              phone: phone
+            }
+          }
+        }
+      };
+
+      utils.getHealthCenterPhone(doc).should.equal(phone);
+  });
+  it('getDistrictPhone works', () => {
+    const phone = '123';
+    const doc = {
+      contact: {
+        parent: {
+          type: 'district_hospital',
+          contact: {
+            phone: phone
+          }
+        }
+      }
+    };
+
+    utils.getDistrictPhone(doc).should.equal(phone);
+  });
+  it('isValidBooleanExpression, a valid expression is a non-empty string', () => {
+    utils.isValidBooleanExpression().should.equal(false);
+    utils.isValidBooleanExpression('').should.equal(false);
+    utils.isValidBooleanExpression(123).should.equal(false);
+    utils.isValidBooleanExpression(['hello']).should.equal(false);
+    utils.isValidBooleanExpression('foo.bar').should.equal(true);
+  });
+  describe('evalExpression', () => {
+    it('evals a given expression', () => {
+      utils.evalExpression({}, '(1+2+3) !== 24').should.equal(true);
+      utils.evalExpression({}, '(1+2+3) === 24').should.equal(false);
+    });
+    it('provides the passed context to the exprssion', () => {
+      utils.evalExpression({doc: {foo: 42, bar: 24}}, 'doc.foo + doc.bar')
+        .should.equal(66);
+    });
+    it('throws an exception if the expression errors', () => {
+      should.Throw(() => utils.evalExpression({}, `doc.foo.bar.smang === 'cats'`));
+    });
+  });
+});

--- a/test/mocha/transitions/accept_patient_reports.js
+++ b/test/mocha/transitions/accept_patient_reports.js
@@ -3,9 +3,10 @@ const sinon = require('sinon').sandbox.create(),
       moment = require('moment');
 
 describe('accept_patient_reports', () => {
-  const transition = require('../../../transitions/accept_patient_reports');
+  const transition = require('../../../transitions/accept_patient_reports'),
+        messages = require('../../../lib/messages');
 
-  beforeEach(done => {
+  afterEach(done => {
     sinon.restore();
     done();
   });
@@ -104,6 +105,32 @@ describe('accept_patient_reports', () => {
         const results = transition._findToClear(registration, now.valueOf(), {silence_type: 'x,y', silence_for: silence_for});
         ids(results).should.deep.equal([1, 2, 3, 4, 31, 41, 6, 7]);
       });
+    });
+  });
+  describe('addMessageToDoc', () => {
+    it('Does not add a message if the bool_expr fails', () => {
+      const doc = {};
+      const config = {messages: [{
+        event_type: 'report_accepted',
+        bool_expr: 'false'
+      }]};
+      const patient = {};
+
+      const stub = sinon.stub(messages, 'addMessage');
+      transition._addMessageToDoc(doc, config, [], patient);
+      stub.callCount.should.equal(0);
+    });
+    it('Adds a message if the bool_expr passes', () => {
+      const doc = {};
+      const config = {messages: [{
+        event_type: 'report_accepted',
+        bool_expr: 'true'
+      }]};
+      const patient = {};
+
+      const stub = sinon.stub(messages, 'addMessage');
+      transition._addMessageToDoc(doc, config, [], patient);
+      stub.callCount.should.equal(1);
     });
   });
 });

--- a/test/mocha/transitions/registration.js
+++ b/test/mocha/transitions/registration.js
@@ -1,0 +1,105 @@
+const should = require('chai').should();
+const sinon = require('sinon').sandbox.create();
+
+describe('registrations', () => {
+  const transition = require('../../../transitions/registration'),
+        messages = require('../../../lib/messages'),
+        utils = require('../../../lib/utils');
+
+  afterEach(done => {
+    sinon.restore();
+    done();
+  });
+
+  describe('addMessages', () => {
+    it('prepops and passes the right information to messages.addMessage', done => {
+      const testPhone = '1234',
+            testMessage = 'A Test Message',
+            testRegistration = 'some registrations',
+            testPatient = 'a patient contact';
+
+      sinon.stub(messages, 'getRecipientPhone').returns(testPhone);
+      sinon.stub(messages, 'getMessage').returns(testMessage);
+      const addMessage = sinon.stub(messages, 'addMessage');
+
+      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, testRegistration);
+      sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPatient);
+
+      const testConfig = {
+        messages: [{
+        },
+        {
+          event_type: 'report_accepted'
+        }]
+      };
+      const testDoc = {
+        fields: {
+          patient_id: '12345'
+        }
+      };
+
+      transition.addMessages({}, testConfig, testDoc, err => {
+        should.not.exist(err);
+        // Registration will send messages with no event_type
+        addMessage.callCount.should.equal(2);
+
+        const expected = {
+          doc: testDoc,
+          phone: testPhone,
+          message: testMessage,
+          templateContext: { next_msg: { minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0 } },
+          registrations: testRegistration,
+          patient: testPatient
+        };
+
+        addMessage.args[0][0].should.deep.equal(expected);
+        addMessage.args[1][0].should.deep.equal(expected);
+        done();
+      });
+    });
+    it('supports ignoring messages based on bool_expr', done => {
+      const testPhone = '1234',
+            testMessage = 'A Test Message',
+            testRegistration = 'some registrations',
+            testPatient = 'a patient contact';
+
+      sinon.stub(messages, 'getRecipientPhone').returns(testPhone);
+      sinon.stub(messages, 'getMessage').returns(testMessage);
+      const addMessage = sinon.stub(messages, 'addMessage');
+
+      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, testRegistration);
+      sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPatient);
+
+      const testConfig = {
+        messages: [{
+        },
+        {
+          event_type: 'report_accepted',
+          bool_expr: '1 === 2'
+        }]
+      };
+      const testDoc = {
+        fields: {
+          patient_id: '12345'
+        }
+      };
+
+      transition.addMessages({}, testConfig, testDoc, err => {
+        should.not.exist(err);
+        addMessage.callCount.should.equal(1);
+
+        const expected = {
+          doc: testDoc,
+          phone: testPhone,
+          message: testMessage,
+          templateContext: { next_msg: { minutes: 0, hours: 0, days: 0, weeks: 0, months: 0, years: 0 } },
+          registrations: testRegistration,
+          patient: testPatient
+        };
+
+        addMessage.args[0][0].should.deep.equal(expected);
+        done();
+      });
+    });
+  });
+});

--- a/test/mocha/transitions/registration.js
+++ b/test/mocha/transitions/registration.js
@@ -23,7 +23,6 @@ describe('registrations', () => {
       const addMessage = sinon.stub(messages, 'addMessage');
 
       sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, testRegistration);
-      sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPatient);
 
       const testConfig = {
         messages: [{
@@ -35,7 +34,8 @@ describe('registrations', () => {
       const testDoc = {
         fields: {
           patient_id: '12345'
-        }
+        },
+        patient: testPatient
       };
 
       transition.addMessages({}, testConfig, testDoc, err => {
@@ -68,7 +68,6 @@ describe('registrations', () => {
       const addMessage = sinon.stub(messages, 'addMessage');
 
       sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, testRegistration);
-      sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, testPatient);
 
       const testConfig = {
         messages: [{
@@ -81,7 +80,8 @@ describe('registrations', () => {
       const testDoc = {
         fields: {
           patient_id: '12345'
-        }
+        },
+        patient: testPatient
       };
 
       transition.addMessages({}, testConfig, testDoc, err => {

--- a/test/unit/accept_patient_reports.js
+++ b/test/unit/accept_patient_reports.js
@@ -79,7 +79,7 @@ exports['onMatch with no patient id adds error msg and response'] = function(tes
 
 // Because patients can be created through the UI and not neccessarily have
 // a registration at all
-exports['handleReport with no registrations does not error'] = function(test) {
+exports['onMatch with no registrations does not error'] = function(test) {
     var doc = {
         fields: { patient_id: 'x' },
         from: '+123'
@@ -98,7 +98,7 @@ exports['handleReport with no registrations does not error'] = function(test) {
         }]
     };
 
-    transition.handleReport(
+    transition._handleReport(
         null,
         null,
         doc,
@@ -138,7 +138,7 @@ exports['handleReport with patient adds reply'] = function(test) {
             recipient: 'reporting_unit'
         }]
     };
-    transition.handleReport(
+    transition._handleReport(
         null,
         null,
         doc,
@@ -156,8 +156,8 @@ exports['handleReport with patient adds reply'] = function(test) {
 
 exports['adding silence_type to handleReport calls _silenceReminders'] = function(test) {
     sinon.stub(transition, '_silenceReminders').callsArgWith(4);
-    const doc = { _id: 'a' };
-    const config = { silence_type: 'x' };
+    const doc = { _id: 'a', fields: { patient_id: 'x'}};
+    const config = { silence_type: 'x', messages: [] };
     const registrations = [
         { id: 'a' }, // should not be silenced as it's the doc being processed
         { id: 'b' }, // should be silenced
@@ -165,7 +165,7 @@ exports['adding silence_type to handleReport calls _silenceReminders'] = functio
     ];
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
     sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, {});
-    transition.handleReport(
+    transition._handleReport(
         null,
         null,
         doc,

--- a/test/unit/lineage.js
+++ b/test/unit/lineage.js
@@ -1,4 +1,5 @@
 const db = require('../../db'),
+      utils = require('../../lib/utils'),
       sinon = require('sinon').sandbox.create(),
       lineage = require('../../lib/lineage');
 
@@ -12,6 +13,7 @@ let report_parentContact,
   report_grandparent,
   report_parent,
   report_contact,
+  report_patient,
   report,
   place_parentContact,
   place_grandparentContact,
@@ -57,6 +59,20 @@ exports.setUp = callback => {
       }
     }
   };
+  report_patient = {
+    _id: 'report-patient',
+    type: 'person',
+    name: 'patient_name',
+    parent: {
+      _id: report_contact._id,
+      parent: {
+        _id: report_parent._id,
+        parent: {
+          _id: report_grandparent._id
+        }
+      }
+    }
+  };
   report = {
     _id: 'report',
     type: 'data_record',
@@ -69,6 +85,9 @@ exports.setUp = callback => {
           _id: report_grandparent._id
         }
       }
+    },
+    fields: {
+      patient_id: 'abc123'
     }
   };
 
@@ -220,17 +239,26 @@ exports['fetchHydratedDoc attaches the lineage'] = test => {
 };
 
 exports['fetchHydratedDoc attaches the full lineage for reports'] = test => {
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, report_patient._id);
+  const viewStub = sinon.stub(db.medic, 'view');
+  viewStub.onCall(0).callsArgWith(3, null, { rows: [
     { doc: report },
     { doc: report_contact },
     { doc: report_parent },
     { doc: report_grandparent }
   ] });
+  viewStub.onCall(1).callsArgWith(3, null, { rows: [
+    { doc: report_patient },
+    { doc: report_contact },
+    { doc: report_parent },
+    { doc: report_grandparent }
+  ] });
+  viewStub.onCall(2).callsArgWith(3, 'Too many calls!');
 
   const fetch = sinon.stub(db.medic, 'fetch');
   fetch.callsFake((options, callback) => {
     const contactDocs = options.keys.map(id => {
-      return [ report_contact, report_parentContact, report_grandparentContact ]
+      return [ report_contact, report_parentContact, report_grandparentContact, report_patient ]
         .find(contact => contact._id === id);
     });
     callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });
@@ -246,10 +274,14 @@ exports['fetchHydratedDoc attaches the full lineage for reports'] = test => {
     // contacts of parents
     test.equals(actual.contact.parent.contact.phone, '+123');
     test.equals(actual.contact.parent.parent.contact.phone, '+456');
+    // patient
+    test.equals(actual.patient.name, report_patient.name);
+    // patient parents
+    test.equals(actual.patient.parent.name, report_contact.name);
 
-    test.equals(fetch.callCount, 1);
+    test.equals(fetch.callCount, 2);
     test.done();
-  });
+  }).catch(console.error);
 };
 
 exports['fetchHydratedDoc attaches the contacts'] = test => {
@@ -420,9 +452,43 @@ exports['minify minifies the contact and lineage'] = test => {
   test.done();
 };
 
+
+exports['minify removes the patient'] = test => {
+  const actual = {
+    _id: 'c',
+    type: 'data_record',
+    patient_id: '123',
+    patient: {
+      _id: 'a',
+      name: 'Alice',
+      patient_id: '123',
+      parent: {
+        _id: 'b',
+        name: 'Bob'
+      }
+    }
+  };
+  const expected = {
+    _id: 'c',
+    type: 'data_record',
+    patient_id: '123'
+  };
+  lineage.minify(actual);
+  test.deepEqual(actual, expected);
+  test.done();
+};
+
 exports['fetchHydratedDoc+minify is noop on a report'] = test => {
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, report_patient._id);
+  const viewStub = sinon.stub(db.medic, 'view');
+  viewStub.onCall(0).callsArgWith(3, null, { rows: [
     { doc: JSON.parse(JSON.stringify(report)) },
+    { doc: report_contact },
+    { doc: report_parent },
+    { doc: report_grandparent }
+  ] });
+  viewStub.onCall(1).callsArgWith(3, null, { rows: [
+    { doc: report_patient },
     { doc: report_contact },
     { doc: report_parent },
     { doc: report_grandparent }
@@ -431,7 +497,7 @@ exports['fetchHydratedDoc+minify is noop on a report'] = test => {
   const fetch = sinon.stub(db.medic, 'fetch');
   fetch.callsFake((options, callback) => {
     const contactDocs = options.keys.map(id => {
-      return [ report_contact, report_parentContact, report_grandparentContact ]
+      return [ report_contact, report_parentContact, report_grandparentContact, report_patient ]
         .find(contact => contact._id === id);
     });
     callback(null, { rows: contactDocs.map(doc => { return {doc: doc}; }) });

--- a/test/unit/lineage.js
+++ b/test/unit/lineage.js
@@ -279,7 +279,7 @@ exports['fetchHydratedDoc attaches the full lineage for reports'] = test => {
     // patient parents
     test.equals(actual.patient.parent.name, report_contact.name);
 
-    test.equals(fetch.callCount, 2);
+    test.equals(fetch.callCount, 1);
     test.done();
   }).catch(console.error);
 };
@@ -555,6 +555,8 @@ exports['hydrateDocs binds contacts and parents'] = test => {
     test.equals(hydratedReport.contact.parent.contact.name, report_parentContact.name);
     test.equals(hydratedReport.contact.parent.parent.name, report_grandparent.name);
     test.equals(hydratedReport.contact.parent.parent.contact.name, report_grandparentContact.name);
+    // TODO: https://github.com/medic/medic-webapp/issues/4003
+    // test.equals(hydratedReport.patient._id, report_patient._id);
 
     test.equals(hydratedPlace.contact.name, place_contact.name);
     test.equals(hydratedPlace.parent.name, place_parent.name);

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -287,57 +287,6 @@ exports['addMessage aliases patient.name to patient_name'] = test => {
     test.done();
 };
 
-exports['getRecipientPhone resolves `clinic` correctly'] = function(test) {
-    var phone = '+13125551213';
-    var doc = {
-        form: 'x',
-        contact: {
-            phone: phone,
-            parent: {
-                contact: {
-                    phone: phone
-                }
-            }
-        }
-    };
-    var result = messages.getRecipientPhone(doc, 'clinic');
-    test.equals(result, phone);
-    test.done();
-};
-
-exports['getRecipientPhone defaults to doc.from if no recipient'] = function(test) {
-    var phone = '+13125551213';
-    var doc = {
-        form: 'x',
-        from: phone
-    };
-    var result = messages.getRecipientPhone(doc);
-    test.equals(result, phone);
-    test.done();
-};
-
-exports['getRecipientPhone defaults to doc.from if no known recipient'] = function(test) {
-    var phone = '+13125551213';
-    var doc = {
-        form: 'x',
-        from: phone
-    };
-    var result = messages.getRecipientPhone(doc, 'greatgrandparent');
-    test.equals(result, phone);
-    test.done();
-};
-
-exports['getRecipientPhone defaults to given default'] = function(test) {
-    var phone = '+13125551213';
-    var doc = {
-        form: 'x',
-        from: '+6666666666'
-    };
-    var result = messages.getRecipientPhone(doc, 'greatgrandparent', phone);
-    test.equals(result, phone);
-    test.done();
-};
-
 exports['getMessage returns empty string on empty config'] = function(test) {
     var config = { messages: [{
         content: '',

--- a/test/unit/patient_registration.js
+++ b/test/unit/patient_registration.js
@@ -140,19 +140,6 @@ exports['getDOB falls back to today if necessary'] = function(test) {
     test.done();
 };
 
-exports['isBoolExprFalse returns false/true based on regex'] = function(test) {
-    var regex1 = '/^\\s*[5]\\d+/.test(doc.foo)',
-        regex2 = '/^\\s*[3]\\d+/.test(doc.foo)',
-        doc = {
-            foo: '533884'
-        };
-    test.equal(transition.isBoolExprFalse(doc, regex1), false);
-    test.equal(transition.isBoolExprFalse(doc, regex2), true);
-    // undefined expr always returns true
-    test.equal(transition.isBoolExprFalse(doc), false);
-    test.done();
-};
-
 exports['valid form adds patient_id and patient document'] = function(test) {
 
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -116,29 +116,6 @@ exports['getClinicName gets name'] = function(test) {
     test.done();
 };
 
-exports['getClinicPhone gets phone'] = function(test) {
-    test.equal(utils.getClinicPhone({
-        contact: {
-            parent: {
-                type: 'clinic',
-                contact: {
-                    phone: '123'
-                }
-            }
-        }
-    }), '123');
-    test.done();
-};
-
-exports['getClinicPhone gets phone if contact'] = function(test) {
-    test.equal(utils.getClinicPhone({
-        contact: {
-            phone: '123'
-        }
-    }), '123');
-    test.done();
-};
-
 exports['addMessage adds uuid'] = function(test) {
     var doc = {},
         message,

--- a/transitions/accept_patient_reports.js
+++ b/transitions/accept_patient_reports.js
@@ -129,8 +129,8 @@ const addErrorsToDoc = (errors, doc, config) => {
 const messageRelevant = (msg, doc) => {
     if (msg.event_type === 'report_accepted') {
         const expr = msg.bool_expr;
-        if (utils.isValidBooleanExpression(expr)) {
-            return utils.evalExpression({doc: doc}, expr);
+        if (utils.isNonEmptyString(expr)) {
+            return utils.evalExpression(expr, {doc: doc});
         } else {
             return true;
         }

--- a/transitions/conditional_alerts.js
+++ b/transitions/conditional_alerts.js
@@ -3,43 +3,44 @@ var config = require('../config'),
     messages = require('../lib/messages'),
     utils = require('../lib/utils'),
     async = require('async'),
-    vm = require('vm'),
     transitionUtils = require('./utils'),
     NAME = 'conditional_alerts';
+
+const runCondition = (condition, context, callback) => {
+    try {
+        callback(null, utils.evalExpression(context, condition));
+    } catch(e) {
+        callback(e.message);
+    }
+};
+
+const evaluateCondition = (doc, alert, callback) => {
+    var context = { doc: doc };
+    if (alert.condition.indexOf(alert.form) === -1) {
+        runCondition(alert.condition, context, callback);
+    } else {
+        utils.getReportsWithSameClinicAndForm({
+            doc: doc,
+            formName: alert.form
+        }, function(err, rows) {
+            if (err) {
+                return callback(err);
+            }
+            rows = _.sortBy(rows, function(row) {
+                return row.reported_date;
+            });
+            context[alert.form] = function(i) {
+                var row = rows[rows.length - 1 - i];
+                return row ? row.doc : row;
+            };
+            runCondition(alert.condition, context, callback);
+        });
+    }
+};
 
 module.exports = {
     _getConfig: function() {
         return _.extend({}, config.get('alerts'));
-    },
-    _runCondition: function(condition, context, callback) {
-        try {
-            callback(null, vm.runInNewContext(condition, context));
-        } catch(e) {
-            callback(e.message);
-        }
-    },
-    _evaluateCondition: function(doc, alert, callback) {
-        var context = { doc: doc };
-        if (alert.condition.indexOf(alert.form) === -1) {
-            module.exports._runCondition(alert.condition, context, callback);
-        } else {
-            utils.getReportsWithSameClinicAndForm({
-                doc: doc,
-                formName: alert.form
-            }, function(err, rows) {
-                if (err) {
-                    return callback(err);
-                }
-                rows = _.sortBy(rows, function(row) {
-                    return row.reported_date;
-                });
-                context[alert.form] = function(i) {
-                    var row = rows[rows.length - 1 - i];
-                    return row ? row.doc : row;
-                };
-                module.exports._runCondition(alert.condition, context, callback);
-            });
-        }
     },
     filter: function(doc) {
         return Boolean(
@@ -58,7 +59,7 @@ module.exports = {
             _.values(config),
             function(alert, callback) {
                 if (alert.form === doc.form) {
-                    module.exports._evaluateCondition(doc, alert, function(err, result) {
+                    evaluateCondition(doc, alert, function(err, result) {
                         if (err) {
                             return callback(err);
                         } else if(result) {

--- a/transitions/conditional_alerts.js
+++ b/transitions/conditional_alerts.js
@@ -8,7 +8,7 @@ var config = require('../config'),
 
 const runCondition = (condition, context, callback) => {
     try {
-        callback(null, utils.evalExpression(context, condition));
+        callback(null, utils.evalExpression(condition, context));
     } catch(e) {
         callback(e.message);
     }

--- a/transitions/default_responses.js
+++ b/transitions/default_responses.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     _isReportedAfterStartDate: function(doc) {
         var self = module.exports,
-            config = self._getConfig('default_responses'),
+            config = self._getConfig(NAME),
             start_date;
 
         function isEmpty() {

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -80,9 +80,9 @@ const parseParams = params => {
 const booleanExpressionFails = (doc, expr) => {
   let result = false;
 
-  if (utils.isValidBooleanExpression(expr)) {
+  if (utils.isNonEmptyString(expr)) {
     try {
-      result = !utils.evalExpression({doc: doc}, expr);
+      result = !utils.evalExpression(expr, {doc: doc});
     } catch (err) {
       // TODO should this count as a fail or as a real error
       logger.warn('Failed to eval boolean expression:');
@@ -99,8 +99,8 @@ const booleanExpressionFails = (doc, expr) => {
 const messageRelevant = (msg, doc) => {
     if (!msg.event_type || msg.event_type === 'report_accepted') {
         const expr = msg.bool_expr;
-        if (utils.isValidBooleanExpression(expr)) {
-            return utils.evalExpression({doc: doc}, expr);
+        if (utils.isNonEmptyString(expr)) {
+            return utils.evalExpression(expr, {doc: doc});
         } else {
             return true;
         }

--- a/transitions/registration.js
+++ b/transitions/registration.js
@@ -321,17 +321,26 @@ module.exports = {
     clear_schedule: (options, cb) => {
       // Registration forms that clear schedules do so fully
       // silence_type will be split again later, so join them back
-      options.report = {
+      const config = {
         silence_type: options.params.join(','),
         silence_for: null
       };
-      acceptPatientReports.handleReport(
-        options.db,
-        options.audit,
-        options.doc,
-        options.patient,
-        options.report,
-        cb);
+
+      utils.getRegistrations({
+        db: options.db,
+        id: options.doc.fields && options.doc.fields.patient_id
+      }, (err, registrations) => {
+        if (err) {
+          return cb(err);
+        }
+
+        acceptPatientReports.silenceRegistrations(
+          options.audit,
+          config,
+          options.doc,
+          registrations,
+          cb);
+      });
     }
   },
   addMessages: (db, config, doc, callback) => {


### PR DESCRIPTION
# Description

Two main changes:
 - Allow for you to set the recipient phone number to an arbitrary JS
   expression, given the doc as context
 - Allow for you to decide whether or not to send out an SMS based on
   an arbitrary JS expression, given the doc as context

medic/medic-webapp#3412

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
