### PR TITLE
Sentinel looks in the old location for its metadata file #4054

### DIFF
--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -196,6 +196,7 @@ exports['loadTransitions does not load system transistions that have been explic
 exports['attach handles missing meta data doc'] = test => {
   const get = sinon.stub(db.medic, 'get');
   get.withArgs('_local/sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
+  get.withArgs('sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
   const fetchHydratedDoc = sinon.stub(lineage, 'fetchHydratedDoc').returns(Promise.resolve({ type: 'data_record' }));
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
@@ -205,7 +206,7 @@ exports['attach handles missing meta data doc'] = test => {
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
-    test.equal(get.callCount, 2);
+    test.equal(get.callCount, 4);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);
@@ -219,6 +220,45 @@ exports['attach handles missing meta data doc'] = test => {
   transitions._attach();
   test.equal(feed.callCount, 1);
   test.equal(feed.args[0][0].since, 0);
+  test.equal(on.callCount, 2);
+  test.equal(on.args[0][0], 'change');
+  test.equal(on.args[1][0], 'error');
+  test.equal(start.callCount, 1);
+  // invoke the change handler
+  on.args[0][1]({ id: 'abc', seq: 55 });
+};
+
+exports['attach handles old meta data doc'] = test => {
+  const get = sinon.stub(db.medic, 'get');
+  get.withArgs('_local/sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
+  get.withArgs('sentinel-meta-data').callsArgWith(1, null, { _id: 'sentinel-meta-data', _rev: '1-123', processed_seq: 22 });
+  const fetchHydratedDoc = sinon.stub(lineage, 'fetchHydratedDoc').returns(Promise.resolve({ type: 'data_record' }));
+  const insert = sinon.stub(db.medic, 'insert').callsArg(1);
+  const destroy = sinon.stub(db.medic, 'destroy').callsArg(2);
+  const on = sinon.stub();
+  const start = sinon.stub();
+  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
+  sinon.stub(audit, 'withNano');
+  // wait for the queue processor
+  transitions._changeQueue.drain = () => {
+    test.equal(get.callCount, 4);
+    test.equal(fetchHydratedDoc.callCount, 1);
+    test.equal(fetchHydratedDoc.args[0][0], 'abc');
+    test.equal(applyTransitions.callCount, 1);
+    test.equal(applyTransitions.args[0][0].change.id, 'abc');
+    test.equal(applyTransitions.args[0][0].change.seq, 55);
+    test.equal(insert.callCount, 1);
+    test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
+    test.equal(insert.args[0][0].processed_seq, 55);
+    test.equal(destroy.callCount, 2);
+    test.equal(destroy.args[0][0], 'sentinel-meta-data');
+    test.equal(destroy.args[0][1], '1-123');
+    test.done();
+  };
+  transitions._attach();
+  test.equal(feed.callCount, 1);
+  test.equal(feed.args[0][0].since, 22);
   test.equal(on.callCount, 2);
   test.equal(on.args[0][0], 'change');
   test.equal(on.args[1][0], 'error');

--- a/test/unit/transitions.js
+++ b/test/unit/transitions.js
@@ -231,10 +231,9 @@ exports['attach handles missing meta data doc'] = test => {
 exports['attach handles old meta data doc'] = test => {
   const get = sinon.stub(db.medic, 'get');
   get.withArgs('_local/sentinel-meta-data').callsArgWith(1, { statusCode: 404 });
-  get.withArgs('sentinel-meta-data').callsArgWith(1, null, { _id: 'sentinel-meta-data', _rev: '1-123', processed_seq: 22 });
+  get.withArgs('sentinel-meta-data').callsArgWith(1, null, { _id: 'sentinel-meta-data', _rev: '1-123', processed_seq: 22});
   const fetchHydratedDoc = sinon.stub(lineage, 'fetchHydratedDoc').returns(Promise.resolve({ type: 'data_record' }));
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
-  const destroy = sinon.stub(db.medic, 'destroy').callsArg(2);
   const on = sinon.stub();
   const start = sinon.stub();
   const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
@@ -248,12 +247,13 @@ exports['attach handles old meta data doc'] = test => {
     test.equal(applyTransitions.callCount, 1);
     test.equal(applyTransitions.args[0][0].change.id, 'abc');
     test.equal(applyTransitions.args[0][0].change.seq, 55);
-    test.equal(insert.callCount, 1);
-    test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
-    test.equal(insert.args[0][0].processed_seq, 55);
-    test.equal(destroy.callCount, 2);
-    test.equal(destroy.args[0][0], 'sentinel-meta-data');
-    test.equal(destroy.args[0][1], '1-123');
+    test.equal(insert.callCount, 3);
+    test.equal(insert.args[0][0]._id, 'sentinel-meta-data');
+    test.equal(insert.args[0][0]._rev, '1-123');
+    test.equal(insert.args[0][0]._deleted, true);
+    // args[1] is a second incorrect call to delete that is an artifact of how Sinon works
+    test.equal(insert.args[2][0]._id, '_local/sentinel-meta-data');
+    test.equal(insert.args[2][0].processed_seq, 55);
     test.done();
   };
   transitions._attach();

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -442,7 +442,7 @@ const getMetaData = callback =>
           _rev: doc._rev,
           _deleted: true
         };
-        console.log('to be clear were deleting', stub, 'was', doc);
+        logger.info('Deleting old metadata document', doc);
         db.medic.insert(stub, err => {
           if (err) {
             return callback(err);

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -437,7 +437,13 @@ const getMetaData = callback =>
         }
 
         // Old doc exists, delete it and return the base doc to be saved later
-        db.medic.destroy(doc._id, doc._rev, err => {
+        const stub = {
+          _id: doc._id,
+          _rev: doc._rev,
+          _deleted: true
+        };
+        console.log('to be clear were deleting', stub, 'was', doc);
+        db.medic.insert(stub, err => {
           if (err) {
             return callback(err);
           }

--- a/transitions/index.js
+++ b/transitions/index.js
@@ -413,50 +413,51 @@ const applyTransitions = (options, callback) => {
     }, callback));
 };
 
+const migrateOldMetaDoc = (doc, callback) => {
+  const stub = {
+    _id: doc._id,
+    _rev: doc._rev,
+    _deleted: true
+  };
+  logger.info('Deleting old metadata document', doc);
+  return db.medic.insert(stub, err => {
+    if (err) {
+      callback(err);
+    } else {
+      doc._id = METADATA_DOCUMENT;
+      delete doc._rev;
+      callback(null, doc);
+    }
+  });
+};
+
 const getMetaData = callback =>
   db.medic.get(METADATA_DOCUMENT, (err, doc) => {
-    if (err) {
-      if (err.statusCode !== 404) {
+    if (!err) {
+      // Doc exists in correct location
+      return callback(null, doc);
+    } else if (err.statusCode !== 404) {
+      return callback(err);
+    }
+
+    // Doc doesn't exist.
+    // Maybe we have the doc in the old location?
+    db.medic.get('sentinel-meta-data', (err, doc) => {
+      if (!err) {
+        // Old doc exists, delete it and return the base doc to be saved later
+        return migrateOldMetaDoc(doc, callback);
+      } else if (err.statusCode !== 404) {
         return callback(err);
       }
 
-      // Doc doesn't exist.
-      // Maybe we have the doc in the old location?
-      return db.medic.get('sentinel-meta-data', (err, doc) => {
-        if (err) {
-          if (err.statusCode !== 404) {
-            return callback(err);
-          }
+      // No doc at all, create and return default
+      doc = {
+        _id: METADATA_DOCUMENT,
+        processed_seq: 0
+      };
 
-          // No doc at all, create and return default
-          doc = {
-            _id: METADATA_DOCUMENT,
-            processed_seq: 0
-          };
-          return callback(null, doc);
-        }
-
-        // Old doc exists, delete it and return the base doc to be saved later
-        const stub = {
-          _id: doc._id,
-          _rev: doc._rev,
-          _deleted: true
-        };
-        logger.info('Deleting old metadata document', doc);
-        db.medic.insert(stub, err => {
-          if (err) {
-            return callback(err);
-          }
-
-          doc._id = METADATA_DOCUMENT;
-          delete doc._rev;
-          callback(null, doc);
-        });
-      });
-    }
-
-    // Doc exists in correct location
-    callback(null, doc);
+      callback(null, doc);
+    });
   });
 
 const getProcessedSeq = callback =>


### PR DESCRIPTION
We used to have a migration that moves the location. However, that can
cause conflicts because Sentinel runs while API runs, including
migrations.

Instead, manage it inside sentinel itself.

At some point in the future we could delete this, once we're confident
everyone has upgraded past that document.

medic/medic-webapp#4054

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch 
